### PR TITLE
GH-463: Improve TZ support for JDBC driver

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
@@ -95,7 +95,7 @@ public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
     } else if (type == Date.class) {
       value = getObject();
     } else {
-      throw new SQLException("invalid class");
+      throw new SQLException("Object type not supported for Date Vector");
     }
     return !type.isPrimitive() && wasNull ? null : type.cast(value);
   }

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
@@ -30,7 +30,6 @@ import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.DateTimeUtils;
@@ -38,9 +37,7 @@ import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.ValueVector;
 
-/**
- * Accessor for the Arrow types: {@link DateDayVector} and {@link DateMilliVector}.
- */
+/** Accessor for the Arrow types: {@link DateDayVector} and {@link DateMilliVector}. */
 public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final Getter getter;
@@ -50,9 +47,9 @@ public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link DateDayVector}.
    *
-   * @param vector             an instance of a DateDayVector.
+   * @param vector an instance of a DateDayVector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
   public ArrowFlightJdbcDateVectorAccessor(
       DateDayVector vector,
@@ -67,7 +64,7 @@ public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link DateMilliVector}.
    *
-   * @param vector             an instance of a DateMilliVector.
+   * @param vector an instance of a DateMilliVector.
    * @param currentRowSupplier the supplier to track the lines.
    */
   public ArrowFlightJdbcDateVectorAccessor(

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -82,8 +82,10 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
   @Override
   public <T> T getObject(final Class<T> type) throws SQLException {
     final Object value;
-    if (!this.isZoned & Set.of(OffsetDateTime.class, ZonedDateTime.class, Instant.class).contains(type)) {
-      throw new SQLException("Vectors without timezones can't be converted to objects with offset/tz info.");
+    if (!this.isZoned
+        & Set.of(OffsetDateTime.class, ZonedDateTime.class, Instant.class).contains(type)) {
+      throw new SQLException(
+          "Vectors without timezones can't be converted to objects with offset/tz info.");
     } else if (type == OffsetDateTime.class) {
       value = getOffsetDateTime();
     } else if (type == LocalDateTime.class) {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -31,6 +31,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
@@ -71,7 +72,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     this.holder = new Holder();
     this.getter = createGetter(vector);
 
+    // whether the vector included TZ info
     this.isZoned = getVectorIsZoned(vector);
+    // non-null, either the vector TZ or default to UTC
     this.timeZone = getTimeZoneForVector(vector);
     this.timeUnit = getTimeUnitForVector(vector);
     this.longToLocalDateTime = getLongToLocalDateTimeForVector(vector, this.timeZone);
@@ -231,11 +234,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     ArrowType.Timestamp arrowType =
         (ArrowType.Timestamp) vector.getField().getFieldType().getType();
 
-    String timezoneName = arrowType.getTimezone();
-    if (timezoneName == null) {
-      return TimeZone.getTimeZone("UTC");
-    }
-
+    String timezoneName = Objects.requireNonNullElse(arrowType.getTimezone(), "UTC");
     return TimeZone.getTimeZone(timezoneName);
   }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -35,16 +35,13 @@ import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.util.DateUtility;
 
-/**
- * Accessor for the Arrow types extending from {@link TimeStampVector}.
- */
+/** Accessor for the Arrow types extending from {@link TimeStampVector}. */
 public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final TimeZone timeZone;
@@ -54,16 +51,12 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
   private final Holder holder;
   private final boolean isZoned;
 
-  /**
-   * Functional interface used to convert a number (in any time resolution) to LocalDateTime.
-   */
+  /** Functional interface used to convert a number (in any time resolution) to LocalDateTime. */
   interface LongToLocalDateTime {
     LocalDateTime fromLong(long value);
   }
 
-  /**
-   * Instantiate a ArrowFlightJdbcTimeStampVectorAccessor for given vector.
-   */
+  /** Instantiate a ArrowFlightJdbcTimeStampVectorAccessor for given vector. */
   public ArrowFlightJdbcTimeStampVectorAccessor(
       TimeStampVector vector,
       IntSupplier currentRowSupplier,
@@ -148,7 +141,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
 
-    // Adjust timestamp to desired calendar (if provided) only if the column includes TZ info, otherwise treat as wall-clock time
+    // Adjust timestamp to desired calendar (if provided) only if the column includes TZ info,
+    // otherwise treat as wall-clock time
     if (calendar != null && this.isZoned) {
       TimeZone timeZone = calendar.getTimeZone();
       long millis = this.timeUnit.toMillis(value);

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -179,8 +179,19 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     if (localDateTime == null) {
       return null;
     }
+    // to prevent breaking changes for those using this, apply the offset that was previously
+    // applied in getLocalDateTime
+    if (calendar != null && !isZoned) {
+      TimeZone timeZone = calendar.getTimeZone();
+      long millis = Timestamp.valueOf(localDateTime).getTime();
+      localDateTime =
+          localDateTime.minus(
+              timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
 
-    return Timestamp.valueOf(localDateTime);
+      return Timestamp.valueOf(localDateTime);
+    } else {
+      return Timestamp.valueOf(localDateTime);
+    }
   }
 
   protected static TimeUnit getTimeUnitForVector(TimeStampVector vector) {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
@@ -27,7 +27,6 @@ import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.ArrowFlightJdbcTime;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -51,9 +50,9 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeNanoVector}.
    *
-   * @param vector             an instance of a TimeNanoVector.
+   * @param vector an instance of a TimeNanoVector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
   public ArrowFlightJdbcTimeVectorAccessor(
       TimeNanoVector vector,
@@ -68,9 +67,9 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeMicroVector}.
    *
-   * @param vector             an instance of a TimeMicroVector.
+   * @param vector an instance of a TimeMicroVector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
   public ArrowFlightJdbcTimeVectorAccessor(
       TimeMicroVector vector,
@@ -85,7 +84,7 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeMilliVector}.
    *
-   * @param vector             an instance of a TimeMilliVector.
+   * @param vector an instance of a TimeMilliVector.
    * @param currentRowSupplier the supplier to track the lines.
    */
   public ArrowFlightJdbcTimeVectorAccessor(
@@ -101,7 +100,7 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeSecVector}.
    *
-   * @param vector             an instance of a TimeSecVector.
+   * @param vector an instance of a TimeSecVector.
    * @param currentRowSupplier the supplier to track the lines.
    */
   public ArrowFlightJdbcTimeVectorAccessor(

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
@@ -131,7 +131,7 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
     } else if (type == Time.class) {
       value = getObject();
     } else {
-      throw new SQLException("invalid class");
+      throw new SQLException("Object type not supported for Time Vector");
     }
     return !type.isPrimitive() && wasNull ? null : type.cast(value);
   }

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
+import com.google.common.base.Strings;
+
 /** SQL Types utility functions. */
 public class SqlTypes {
   private static final Map<Integer, String> typeIdToName = new HashMap<>();
@@ -121,10 +123,10 @@ public class SqlTypes {
         return Types.TIME;
       case Timestamp:
         String tz = ((ArrowType.Timestamp) arrowType).getTimezone();
-        if (tz != null) {
-          return Types.TIMESTAMP_WITH_TIMEZONE;
-        } else {
+        if (Strings.isNullOrEmpty(tz)) {
           return Types.TIMESTAMP;
+        } else {
+          return Types.TIMESTAMP_WITH_TIMEZONE;
         }
       case Bool:
         return Types.BOOLEAN;

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
@@ -121,7 +121,7 @@ public class SqlTypes {
         return Types.TIME;
       case Timestamp:
         String tz = ((ArrowType.Timestamp) arrowType).getTimezone();
-        if (tz != null){
+        if (tz != null) {
           return Types.TIMESTAMP_WITH_TIMEZONE;
         } else {
           return Types.TIMESTAMP;

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
@@ -16,13 +16,12 @@
  */
 package org.apache.arrow.driver.jdbc.utils;
 
+import com.google.common.base.Strings;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
-
-import com.google.common.base.Strings;
 
 /** SQL Types utility functions. */
 public class SqlTypes {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
@@ -120,7 +120,12 @@ public class SqlTypes {
       case Time:
         return Types.TIME;
       case Timestamp:
-        return Types.TIMESTAMP;
+        String tz = ((ArrowType.Timestamp) arrowType).getTimezone();
+        if (tz != null){
+          return Types.TIMESTAMP_WITH_TIMEZONE;
+        } else {
+          return Types.TIMESTAMP;
+        }
       case Bool:
         return Types.BOOLEAN;
       case Decimal:

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadataTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadataTest.java
@@ -299,8 +299,9 @@ public class ArrowDatabaseMetadataTest {
   private static Connection connection;
 
   static {
-    List<Integer> expectedGetColumnsDataTypes = Arrays.asList(3, 93, 4);
-    List<String> expectedGetColumnsTypeName = Arrays.asList("DECIMAL", "TIMESTAMP", "INTEGER");
+    List<Integer> expectedGetColumnsDataTypes = Arrays.asList(3, 2014, 4);
+    List<String> expectedGetColumnsTypeName =
+        Arrays.asList("DECIMAL", "TIMESTAMP_WITH_TIMEZONE", "INTEGER");
     List<Integer> expectedGetColumnsRadix = Arrays.asList(10, null, 10);
     List<Integer> expectedGetColumnsColumnSize = Arrays.asList(5, 29, 10);
     List<Integer> expectedGetColumnsDecimalDigits = Arrays.asList(2, 9, 0);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -215,9 +215,10 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
         vector,
         (accessor, currentRow) -> {
           final LocalDateTime value = accessor.getObject(LocalDateTime.class);
+          final LocalDateTime expectedValue =
+              getZonedDateTime(currentRow, expectedTimeZone).toLocalDateTime();
 
-          assertThat(
-              value, equalTo(getZonedDateTime(currentRow, expectedTimeZone).toLocalDateTime()));
+          assertThat(value, equalTo(expectedValue));
           assertThat(accessor.wasNull(), is(false));
         });
   }
@@ -234,8 +235,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
         vector,
         (accessor, currentRow) -> {
           final Instant value = accessor.getObject(Instant.class);
+          final Instant expectedValue = getZonedDateTime(currentRow, expectedTimeZone).toInstant();
 
-          assertThat(value, equalTo(getZonedDateTime(currentRow, expectedTimeZone).toInstant()));
+          assertThat(value, equalTo(expectedValue));
           assertThat(accessor.wasNull(), is(false));
         });
   }
@@ -252,10 +254,11 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
         vector,
         (accessor, currentRow) -> {
           final OffsetDateTime value = accessor.getObject(OffsetDateTime.class);
-          final OffsetDateTime vectorValue =
+          final OffsetDateTime expectedValue =
               getZonedDateTime(currentRow, expectedTimeZone).toOffsetDateTime();
-          assertThat(value, equalTo(vectorValue));
-          assertThat(value.getOffset(), equalTo(vectorValue.getOffset()));
+
+          assertThat(value, equalTo(expectedValue));
+          assertThat(value.getOffset(), equalTo(expectedValue.getOffset()));
           assertThat(accessor.wasNull(), is(false));
         });
   }
@@ -272,8 +275,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
         vector,
         (accessor, currentRow) -> {
           final ZonedDateTime value = accessor.getObject(ZonedDateTime.class);
+          final ZonedDateTime expectedValue = getZonedDateTime(currentRow, expectedTimeZone);
 
-          assertThat(value, equalTo(getZonedDateTime(currentRow, expectedTimeZone)));
+          assertThat(value, equalTo(expectedValue));
           assertThat(value.getZone(), equalTo(ZoneId.of(expectedTimeZone)));
           assertThat(accessor.wasNull(), is(false));
         });

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -20,8 +20,10 @@ import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdb
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.Date;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -230,15 +232,20 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       throws Exception {
     setup(vectorSupplier);
     final String expectedTimeZone = Objects.requireNonNullElse(timeZone, "UTC");
-
+    final boolean vectorHasTz = timeZone != null;
     accessorIterator.iterate(
         vector,
         (accessor, currentRow) -> {
-          final Instant value = accessor.getObject(Instant.class);
-          final Instant expectedValue = getZonedDateTime(currentRow, expectedTimeZone).toInstant();
+          if (vectorHasTz) {
+            final Instant value = accessor.getObject(Instant.class);
+            final Instant expectedValue =
+                getZonedDateTime(currentRow, expectedTimeZone).toInstant();
 
-          assertThat(value, equalTo(expectedValue));
-          assertThat(accessor.wasNull(), is(false));
+            assertThat(value, equalTo(expectedValue));
+            assertThat(accessor.wasNull(), is(false));
+          } else {
+            assertThrows(SQLException.class, () -> accessor.getObject(Instant.class));
+          }
         });
   }
 
@@ -249,17 +256,21 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       throws Exception {
     setup(vectorSupplier);
     final String expectedTimeZone = Objects.requireNonNullElse(timeZone, "UTC");
-
+    final boolean vectorHasTz = timeZone != null;
     accessorIterator.iterate(
         vector,
         (accessor, currentRow) -> {
-          final OffsetDateTime value = accessor.getObject(OffsetDateTime.class);
-          final OffsetDateTime expectedValue =
-              getZonedDateTime(currentRow, expectedTimeZone).toOffsetDateTime();
+          if (vectorHasTz) {
+            final OffsetDateTime value = accessor.getObject(OffsetDateTime.class);
+            final OffsetDateTime expectedValue =
+                getZonedDateTime(currentRow, expectedTimeZone).toOffsetDateTime();
 
-          assertThat(value, equalTo(expectedValue));
-          assertThat(value.getOffset(), equalTo(expectedValue.getOffset()));
-          assertThat(accessor.wasNull(), is(false));
+            assertThat(value, equalTo(expectedValue));
+            assertThat(value.getOffset(), equalTo(expectedValue.getOffset()));
+            assertThat(accessor.wasNull(), is(false));
+          } else {
+            assertThrows(SQLException.class, () -> accessor.getObject(OffsetDateTime.class));
+          }
         });
   }
 
@@ -270,16 +281,20 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       throws Exception {
     setup(vectorSupplier);
     final String expectedTimeZone = Objects.requireNonNullElse(timeZone, "UTC");
-
+    final boolean vectorHasTz = timeZone != null;
     accessorIterator.iterate(
         vector,
         (accessor, currentRow) -> {
-          final ZonedDateTime value = accessor.getObject(ZonedDateTime.class);
-          final ZonedDateTime expectedValue = getZonedDateTime(currentRow, expectedTimeZone);
+          if (vectorHasTz) {
+            final ZonedDateTime value = accessor.getObject(ZonedDateTime.class);
+            final ZonedDateTime expectedValue = getZonedDateTime(currentRow, expectedTimeZone);
 
-          assertThat(value, equalTo(expectedValue));
-          assertThat(value.getZone(), equalTo(ZoneId.of(expectedTimeZone)));
-          assertThat(accessor.wasNull(), is(false));
+            assertThat(value, equalTo(expectedValue));
+            assertThat(value.getZone(), equalTo(ZoneId.of(expectedTimeZone)));
+            assertThat(accessor.wasNull(), is(false));
+          } else {
+            assertThrows(SQLException.class, () -> accessor.getObject(ZonedDateTime.class));
+          }
         });
   }
 

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -16,8 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
-import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor.getTimeUnitForVector;
-import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor.getTimeZoneForVector;
+import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -183,6 +182,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
+    boolean hasTz = getVectorIsZoned(vector);
 
     accessorIterator.iterate(
         vector,
@@ -190,9 +190,14 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
           final Timestamp result = accessor.getTimestamp(calendar);
 
-          long offset =
-              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
-                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          long offset;
+          if (hasTz) {
+            offset =
+                (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                    - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          } else {
+            offset = 0;
+          }
 
           assertThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
           assertThat(accessor.wasNull(), is(false));
@@ -231,6 +236,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
+    boolean hasTz = getVectorIsZoned(vector);
 
     accessorIterator.iterate(
         vector,
@@ -238,9 +244,14 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Date resultWithoutCalendar = accessor.getDate(null);
           final Date result = accessor.getDate(calendar);
 
-          long offset =
-              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
-                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          long offset;
+          if (hasTz) {
+            offset =
+                (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                    - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          } else {
+            offset = 0;
+          }
 
           assertThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
           assertThat(accessor.wasNull(), is(false));
@@ -279,6 +290,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
+    boolean hasTz = getVectorIsZoned(vector);
 
     accessorIterator.iterate(
         vector,
@@ -286,9 +298,14 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Time resultWithoutCalendar = accessor.getTime(null);
           final Time result = accessor.getTime(calendar);
 
-          long offset =
-              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
-                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          long offset;
+          if (hasTz) {
+            offset =
+                (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                    - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          } else {
+            offset = 0;
+          }
 
           assertThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
           assertThat(accessor.wasNull(), is(false));

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -404,6 +404,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     return expectedTimestamp;
   }
 
+  /** ZonedDateTime contains all necessary information to generate any java.time object. */
   private ZonedDateTime getZonedDateTime(int currentRow, String timeZone) {
     Object object = vector.getObject(currentRow);
     TimeZone tz = TimeZone.getTimeZone(timeZone);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -412,12 +412,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       expectedTimestamp = ((LocalDateTime) object).atZone(tz.toZoneId());
     } else if (object instanceof Long) {
       TimeUnit timeUnit = getTimeUnitForVector(vector);
-      long millis = timeUnit.toMillis((Long) object);
-      long offset = tz.getOffset(millis);
-      // TODO: should we actually add the offset here? I'm not completely sure how the value is
-      // stored in the vector
-      LocalDateTime local = new Timestamp(millis + offset).toLocalDateTime();
-      expectedTimestamp = ZonedDateTime.of(local, tz.toZoneId());
+      Instant instant = Instant.ofEpochMilli(timeUnit.toMillis((Long) object));
+      expectedTimestamp = ZonedDateTime.ofInstant(instant, tz.toZoneId());
     }
     return expectedTimestamp;
   }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -182,7 +182,6 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
-    boolean hasTz = getVectorIsZoned(vector);
 
     accessorIterator.iterate(
         vector,
@@ -190,14 +189,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
           final Timestamp result = accessor.getTimestamp(calendar);
 
-          long offset;
-          if (hasTz) {
-            offset =
-                (long) timeZone.getOffset(resultWithoutCalendar.getTime())
-                    - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
-          } else {
-            offset = 0;
-          }
+          long offset =
+              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
           assertThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
           assertThat(accessor.wasNull(), is(false));
@@ -236,7 +230,6 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
-    boolean hasTz = getVectorIsZoned(vector);
 
     accessorIterator.iterate(
         vector,
@@ -244,14 +237,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Date resultWithoutCalendar = accessor.getDate(null);
           final Date result = accessor.getDate(calendar);
 
-          long offset;
-          if (hasTz) {
-            offset =
-                (long) timeZone.getOffset(resultWithoutCalendar.getTime())
-                    - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
-          } else {
-            offset = 0;
-          }
+          long offset =
+              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
           assertThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
           assertThat(accessor.wasNull(), is(false));
@@ -290,7 +278,6 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
-    boolean hasTz = getVectorIsZoned(vector);
 
     accessorIterator.iterate(
         vector,
@@ -298,14 +285,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Time resultWithoutCalendar = accessor.getTime(null);
           final Time result = accessor.getTime(calendar);
 
-          long offset;
-          if (hasTz) {
-            offset =
-                (long) timeZone.getOffset(resultWithoutCalendar.getTime())
-                    - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
-          } else {
-            offset = 0;
-          }
+          long offset =
+              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
           assertThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
           assertThat(accessor.wasNull(), is(false));

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/SqlTypesTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/SqlTypesTest.java
@@ -50,7 +50,13 @@ public class SqlTypesTest {
         Types.TIME, getSqlTypeIdFromArrowType(new ArrowType.Time(TimeUnit.MILLISECOND, 32)));
     assertEquals(
         Types.TIMESTAMP,
+        getSqlTypeIdFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)));
+    assertEquals(
+        Types.TIMESTAMP,
         getSqlTypeIdFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "")));
+    assertEquals(
+        Types.TIMESTAMP_WITH_TIMEZONE,
+        getSqlTypeIdFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC")));
 
     assertEquals(Types.BOOLEAN, getSqlTypeIdFromArrowType(new ArrowType.Bool()));
 
@@ -97,7 +103,13 @@ public class SqlTypesTest {
     assertEquals("TIME", getSqlTypeNameFromArrowType(new ArrowType.Time(TimeUnit.MILLISECOND, 32)));
     assertEquals(
         "TIMESTAMP",
+        getSqlTypeNameFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)));
+    assertEquals(
+        "TIMESTAMP",
         getSqlTypeNameFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "")));
+    assertEquals(
+        "TIMESTAMP_WITH_TIMEZONE",
+        getSqlTypeNameFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC")));
 
     assertEquals("BOOLEAN", getSqlTypeNameFromArrowType(new ArrowType.Bool()));
 


### PR DESCRIPTION
This PR adds support for natively fetching `java.time.*` objects through the JDBC driver.

DateVector
- getObject(LocalDate.class)

DateTimeVector
- getObject(OffsetDateTime.class)
- getObject(LocalDateTime.class)
- getObject(ZonedDateTime.class)
- getObject(Instant.class)

TimeVector
- getObject(LocalTime.class)

This PR also changes the behavior for vectors that include TZ info. These will now return as `TIMESTAMP_WITH_TIMEZONE`. 

The behavior for different ways to access a TimeStampVector are as follows:

|                                 | Vector with TZ                                                                                             | Vector W/O TZ                                                                             |
|---------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| getTimestamp()                  | Get timestamp in the vector TZ                                                                             | Get timestamp in UTC                                                                      |
| getTimestamp(calendar)          | Get timestamp by adjusting from the vector TZ to the desired calendar TZ                                   | Get timestamp by adjusting from UTC to the desired calendar TZ (a bug, IMO)                            |
| getObject(LocalDateTime.class)  | Get LocalDateTime by taking the timestamp at the vector TZ and taking the "wall-clock" time at that moment | Treat the epoch value in the vector as the "wall-clock" time                              |
| getObject(Instant.class)        | Get Instant represented by the value in the vector TZ                                                      | Get Instant represented by the value in UTC                                               |
| getObject(OffsetDateTime.class) | Get OffsetDateTime represented by the value in the vector TZ (will account for daylight adjustment)        | Get OffsetDateTime represented by the value in UTC (will account for daylight adjustment) |
| getObject(ZonedDateTime.class)  | Get ZonedDateTime represented by the value in the vector at in its TZ                                      | Get ZonedDateTime represented by the value in the vector at in UTC                        |

Closes #463