### PR TITLE
GH-469: Unify `ValueVector.getObject` and `VariableWidthFieldVector.get` behavior about null value

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -149,7 +149,10 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector
    */
   @Override
   public byte[] getObject(int index) {
-    return get(index);
+    if (isSet(index) == 0) {
+      return null;
+    }
+    return get(valueBuffer, index, byteWidth);
   }
 
   public int getByteWidth() {

--- a/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
@@ -16,6 +16,8 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReusableBuffer;
 import org.apache.arrow.vector.complex.impl.LargeVarBinaryReaderImpl;
@@ -95,7 +97,7 @@ public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector
    */
   public byte[] get(int index) {
     assert index >= 0;
-    if (isSet(index) == 0) {
+    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
       return null;
     }
     final long startOffset = getStartOffset(index);
@@ -127,7 +129,14 @@ public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector
    */
   @Override
   public byte[] getObject(int index) {
-    return get(index);
+    if (isSet(index) == 0) {
+      return null;
+    }
+    final long startOffset = getStartOffset(index);
+    final long dataLength = getEndOffset(index) - startOffset;
+    final byte[] result = new byte[(int) dataLength];
+    valueBuffer.getBytes(startOffset, result, 0, (int) dataLength);
+    return result;
   }
 
   /**

--- a/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
@@ -98,7 +98,7 @@ public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      return null;
+      throw new IllegalStateException("Value at index is null");
     }
     final long startOffset = getStartOffset(index);
     final long dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
@@ -98,7 +98,7 @@ public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
+      return null;
     }
     final long startOffset = getStartOffset(index);
     final long dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
@@ -102,7 +102,7 @@ public final class LargeVarCharVector extends BaseLargeVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      return null;
+      throw new IllegalStateException("Value at index is null");
     }
     final long startOffset = getStartOffset(index);
     final long dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
@@ -102,7 +102,7 @@ public final class LargeVarCharVector extends BaseLargeVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
+      return null;
     }
     final long startOffset = getStartOffset(index);
     final long dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
@@ -101,7 +101,7 @@ public final class LargeVarCharVector extends BaseLargeVariableWidthVector
   @Override
   public byte[] get(int index) {
     assert index >= 0;
-    if (isSet(index) == 0) {
+    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
       return null;
     }
     final long startOffset = getStartOffset(index);
@@ -120,7 +120,7 @@ public final class LargeVarCharVector extends BaseLargeVariableWidthVector
   @Override
   public Text getObject(int index) {
     assert index >= 0;
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
+    if (isSet(index) == 0) {
       return null;
     }
 

--- a/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -264,7 +264,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
    * Get friendly type object from the vector.
    *
    * @param index index of object to get
-   * @return friendly type object
+   * @return friendly type object, null if value is unset
    */
   Object getObject(int index);
 

--- a/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -128,7 +128,15 @@ public final class VarBinaryVector extends BaseVariableWidthVector
    */
   @Override
   public byte[] getObject(int index) {
-    return get(index);
+    if (isSet(index) == 0) {
+      return null;
+    }
+
+    final int startOffset = getStartOffset(index);
+    final int dataLength = getEndOffset(index) - startOffset;
+    final byte[] result = new byte[dataLength];
+    valueBuffer.getBytes(startOffset, result, 0, dataLength);
+    return result;
   }
 
   /**

--- a/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -97,7 +97,7 @@ public final class VarBinaryVector extends BaseVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
+      return null;
     }
     final int startOffset = getStartOffset(index);
     final int dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -97,7 +97,7 @@ public final class VarBinaryVector extends BaseVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      return null;
+      throw new IllegalStateException("Value at index is null");
     }
     final int startOffset = getStartOffset(index);
     final int dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -117,7 +117,7 @@ public final class VarCharVector extends BaseVariableWidthVector
   @Override
   public Text getObject(int index) {
     assert index >= 0;
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
+    if (isSet(index) == 0) {
       return null;
     }
 

--- a/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -99,7 +99,7 @@ public final class VarCharVector extends BaseVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
+      return null;
     }
     final int startOffset = getStartOffset(index);
     final int dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -99,7 +99,7 @@ public final class VarCharVector extends BaseVariableWidthVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      return null;
+      throw new IllegalStateException("Value at index is null");
     }
     final int startOffset = getStartOffset(index);
     final int dataLength = getEndOffset(index) - startOffset;

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -97,7 +97,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      return null;
+      throw new IllegalStateException("Value at index is null");
     }
     return getData(index);
   }

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -122,7 +122,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    */
   @Override
   public byte[] getObject(int index) {
-    if(isSet(index) == 0) {
+    if (isSet(index) == 0) {
       return null;
     }
     return getData(index);

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -97,7 +97,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
+      return null;
     }
     return getData(index);
   }

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -122,7 +122,10 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    */
   @Override
   public byte[] getObject(int index) {
-    return get(index);
+    if(isSet(index) == 0) {
+      return null;
+    }
+    return getData(index);
   }
 
   /**

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -115,7 +115,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
   @Override
   public Text getObject(int index) {
     assert index >= 0;
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
+    if (isSet(index) == 0) {
       return null;
     }
 

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -101,7 +101,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      return null;
+      throw new IllegalStateException("Value at index is null");
     }
     return getData(index);
   }

--- a/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -101,7 +101,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
+      return null;
     }
     return getData(index);
   }


### PR DESCRIPTION
Fixes #469.