### PR TITLE
allow to override Base(Large)RepeatedValueViewVector

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/complex/BaseLargeRepeatedValueViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/BaseLargeRepeatedValueViewVector.java
@@ -44,7 +44,7 @@ import org.apache.arrow.vector.util.SchemaChangeRuntimeException;
 public abstract class BaseLargeRepeatedValueViewVector extends BaseValueVector
     implements RepeatedValueVector, FieldVector {
   public static final FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
-  public static final String DATA_VECTOR_NAME = "$data$";
+  public static String DATA_VECTOR_NAME = "$data$";
 
   public static final byte OFFSET_WIDTH = 8;
   public static final byte SIZE_WIDTH = 8;


### PR DESCRIPTION
This is done as different arrow implementation have different default list item field name

For example, Rust implementation of Arrow (`arrow-rs`) has default value of `item` (https://github.com/apache/arrow-rs/blob/4f1f6e57c568fae8233ab9da7d7c7acdaea4112a/arrow-schema/src/field.rs#L125).

And according to the specification, the name of the list is not required to be a specific string. so to make it easier to use Java Arrow implementation with other implementation of Arrow, I'm making the `DATA_VECTOR_NAME` configurable