### PR TITLE
GH-494: [Flight] Allow configuring connect timeout in JDBC

### DIFF
--- a/flight/flight-sql-jdbc-core/pom.xml
+++ b/flight/flight-sql-jdbc-core/pom.xml
@@ -48,6 +48,21 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
     </dependency>

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
@@ -113,6 +113,7 @@ public final class ArrowFlightConnection extends AvaticaConnection {
           .withRetainCookies(config.retainCookies())
           .withRetainAuth(config.retainAuth())
           .withCatalog(config.getCatalog())
+          .withConnectTimeout(config.getConnectTimeout())
           .build();
     } catch (final SQLException e) {
       try {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.utils;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -163,6 +164,16 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
     return ArrowFlightConnectionProperty.CATALOG.getString(properties);
   }
 
+  /** The initial connect timeout. */
+  public Duration getConnectTimeout() {
+    Integer timeout = ArrowFlightConnectionProperty.CONNECT_TIMEOUT_MILLIS.getInteger(properties);
+    if (timeout == null) {
+      return Duration.ofMillis(
+          (int) ArrowFlightConnectionProperty.CONNECT_TIMEOUT_MILLIS.defaultValue());
+    }
+    return Duration.ofMillis(timeout);
+  }
+
   /**
    * Gets the {@link CallOption}s from this {@link ConnectionConfig}.
    *
@@ -213,7 +224,9 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
     TOKEN("token", null, Type.STRING, false),
     RETAIN_COOKIES("retainCookies", true, Type.BOOLEAN, false),
     RETAIN_AUTH("retainAuth", true, Type.BOOLEAN, false),
-    CATALOG("catalog", null, Type.STRING, false);
+    CATALOG("catalog", null, Type.STRING, false),
+    CONNECT_TIMEOUT_MILLIS("connectTimeoutMs", 10000, Type.NUMBER, false),
+    ;
 
     private final String camelName;
     private final Object defaultValue;

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
@@ -147,6 +147,7 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
     assertNull(builder.clientCertificatePath);
     assertNull(builder.clientKeyPath);
     assertEquals(Optional.empty(), builder.catalog);
+    assertNull(builder.connectTimeout);
   }
 
   @Test

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImplTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImplTest.java
@@ -18,6 +18,7 @@ package org.apache.arrow.driver.jdbc.utils;
 
 import static java.lang.Runtime.getRuntime;
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.CATALOG;
+import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.CONNECT_TIMEOUT_MILLIS;
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.HOST;
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.PASSWORD;
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.PORT;
@@ -27,6 +28,7 @@ import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.time.Duration;
 import java.util.Properties;
 import java.util.Random;
 import java.util.function.Function;
@@ -59,49 +61,67 @@ public final class ArrowFlightConnectionConfigImplTest {
   public void testGetProperty(
       ArrowFlightConnectionProperty property,
       Object value,
+      Object expected,
       Function<ArrowFlightConnectionConfigImpl, ?> configFunction) {
     properties.put(property.camelName(), value);
     arrowFlightConnectionConfigFunction = configFunction;
-    assertThat(configFunction.apply(arrowFlightConnectionConfig), is(value));
-    assertThat(arrowFlightConnectionConfigFunction.apply(arrowFlightConnectionConfig), is(value));
+    assertThat(configFunction.apply(arrowFlightConnectionConfig), is(expected));
+    assertThat(
+        arrowFlightConnectionConfigFunction.apply(arrowFlightConnectionConfig), is(expected));
   }
 
   public static Stream<Arguments> provideParameters() {
+    int port = RANDOM.nextInt(Short.toUnsignedInt(Short.MAX_VALUE));
+    boolean useEncryption = RANDOM.nextBoolean();
+    int threadPoolSize = RANDOM.nextInt(getRuntime().availableProcessors());
     return Stream.of(
         Arguments.of(
             HOST,
+            "host",
             "host",
             (Function<ArrowFlightConnectionConfigImpl, ?>)
                 ArrowFlightConnectionConfigImpl::getHost),
         Arguments.of(
             PORT,
-            RANDOM.nextInt(Short.toUnsignedInt(Short.MAX_VALUE)),
+            port,
+            port,
             (Function<ArrowFlightConnectionConfigImpl, ?>)
                 ArrowFlightConnectionConfigImpl::getPort),
         Arguments.of(
             USER,
+            "user",
             "user",
             (Function<ArrowFlightConnectionConfigImpl, ?>)
                 ArrowFlightConnectionConfigImpl::getUser),
         Arguments.of(
             PASSWORD,
             "password",
+            "password",
             (Function<ArrowFlightConnectionConfigImpl, ?>)
                 ArrowFlightConnectionConfigImpl::getPassword),
         Arguments.of(
             USE_ENCRYPTION,
-            RANDOM.nextBoolean(),
+            useEncryption,
+            useEncryption,
             (Function<ArrowFlightConnectionConfigImpl, ?>)
                 ArrowFlightConnectionConfigImpl::useEncryption),
         Arguments.of(
             THREAD_POOL_SIZE,
-            RANDOM.nextInt(getRuntime().availableProcessors()),
+            threadPoolSize,
+            threadPoolSize,
             (Function<ArrowFlightConnectionConfigImpl, ?>)
                 ArrowFlightConnectionConfigImpl::threadPoolSize),
         Arguments.of(
             CATALOG,
             "catalog",
+            "catalog",
             (Function<ArrowFlightConnectionConfigImpl, ?>)
-                ArrowFlightConnectionConfigImpl::getCatalog));
+                ArrowFlightConnectionConfigImpl::getCatalog),
+        Arguments.of(
+            CONNECT_TIMEOUT_MILLIS,
+            5000,
+            Duration.ofMillis(5000),
+            (Function<ArrowFlightConnectionConfigImpl, ?>)
+                ArrowFlightConnectionConfigImpl::getConnectTimeout));
   }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/FallbackFlightSqlProducer.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/FallbackFlightSqlProducer.java
@@ -109,6 +109,16 @@ public class FallbackFlightSqlProducer extends BasicFlightSqlProducer {
                       Location.forGrpcInsecure("localhost", 9999),
                       Location.reuseConnection())
                   .build());
+    } else if (query.equals("fallback with unresolvable")) {
+      endpoints =
+          Collections.singletonList(
+              FlightEndpoint.builder(
+                      ticket,
+                      // Inaccessible IP
+                      // https://stackoverflow.com/questions/10456044/what-is-a-good-invalid-ip-address-to-use-for-unit-tests
+                      Location.forGrpcInsecure("203.0.113.0", 9999),
+                      Location.reuseConnection())
+                  .build());
     } else {
       throw CallStatus.UNIMPLEMENTED.withDescription(query).toRuntimeException();
     }


### PR DESCRIPTION
Allow configuring the connect timeout via `connectTimeoutMs` so that the driver doesn't wait so long before giving up on unreachable locations.

Fixes #494.