### PR TITLE
GH-512: [Release] Fix `svn add` target

### DIFF
--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -51,7 +51,7 @@ git push origin "${tag}"
 release_id="apache-arrow-java-${version}"
 dist_url="https://dist.apache.org/repos/dist/release/arrow"
 dist_base_dir="dev/release/dist"
-dist_dir="dev/release/dist/${release_id}"
+dist_dir="${dist_base_dir}/${release_id}"
 echo "Checking out ${dist_url}"
 rm -rf "${dist_base_dir}"
 svn co --depth=empty "${dist_url}" "${dist_base_dir}"
@@ -62,7 +62,7 @@ gh release download "${rc_tag}" \
 
 echo "Uploading to release/"
 pushd "${dist_base_dir}"
-svn add .
+svn add "${release_id}"
 svn ci -m "Apache Arrow Java ${version}"
 popd
 rm -rf "${dist_base_dir}"


### PR DESCRIPTION
Fixes GH-512.

We can't use `svn add .` here. If we use `.`, we'll get the following error:

    svn: warning: W150002: '/tmp/arrow-java/dev/release/dist' is already under version control
    svn: E200009: Could not add all targets because some targets are already versioned
    svn: E200009: Illegal target for the requested operation