### PR TITLE
GH-515: Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Execute Docker Build
         env:
           # Enables build caching, but not strictly required
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           docker compose run \
             -e CI=true \
@@ -107,12 +107,12 @@ jobs:
       - name: Build
         shell: bash
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ci/scripts/build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ci/scripts/test.sh $(pwd) $(pwd)/build
 
   windows:
@@ -138,12 +138,12 @@ jobs:
       - name: Build
         shell: bash
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ci/scripts/build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ci/scripts/test.sh $(pwd) $(pwd)/build
 
   integration:

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -21,7 +21,7 @@
 -->
 <develocity xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
-        <url>https://ge.apache.org</url>
+        <url>https://develocity.apache.org</url>
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -26,14 +26,12 @@
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
-        <capture>
-            <fileFingerprints>true</fileFingerprints>
-            <buildLogging>true</buildLogging>
-            <testLogging>true</testLogging>
-        </capture>
         <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
-        <publishing><onlyIf>true</onlyIf></publishing>
-        <publishIfAuthenticated>true</publishIfAuthenticated>
+        <publishing>
+            <onlyIf>
+                <![CDATA[authenticated]]>
+            </onlyIf>
+        </publishing>
         <obfuscation>
             <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
         </obfuscation>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -20,6 +20,7 @@
 
 -->
 <develocity xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+    <projectId>arrow</projectId>
     <server>
         <url>https://develocity.apache.org</url>
         <allowUntrusted>false</allowUntrusted>


### PR DESCRIPTION
This PR migrates the Arrow project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR sets a projectId for use by Develocity.

Fixes #515 