### PR TITLE
GH-518: Cleanup apache-arrow-java.tar.gz created by pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,8 @@ repos:
             git archive HEAD \
               --prefix=apache-arrow-java/ \
               --output=apache-arrow-java.tar.gz && \
-              dev/release/run_rat.sh apache-arrow-java.tar.gz"
+              dev/release/run_rat.sh apache-arrow-java.tar.gz && \
+              rm -f apache-arrow-java.tar.gz"
         always_run: true
         pass_filenames: false
   - repo: https://github.com/koalaman/shellcheck-precommit


### PR DESCRIPTION
Fixes GH-518.