### PR TITLE
GH-549: Fix Incorrect NOTICE File and Update LICENSE Headers for Third-Party Code Compliance

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -205,13 +205,13 @@
 vector/src/main/java/org/apache/arrow/vector/util/IntObjectHashMap.java
 vector/src/main/java/org/apache/arrow/vector/util/IntObjectMap.java
 
-These file are derived from code from Netty, which is made available under the
+These file are derived from code from Netty(4.1.117), which is made available under the
 Apache License 2.0.
 
 --------------------------------------------------------------------------------
 memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
 
-This product includes software from Google Guava, which is made available under the
+This product includes software from Google Guava(33.4.0), which is made available under the
 Apache License 2.0.
   * Copyright (C) 2007 The Guava Authors
   * https://github.com/google/guava

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,15 @@
 Apache Arrow Java
-Copyright 2016-2024 The Apache Software Foundation
+Copyright 2016-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+This product contains code from the Netty Project:
+---------------------------------------------------
+The Netty Project
+=================
+Please visit the Netty web site for more information:
+  * http://netty.io/
+
+Copyright 2014 The Netty Project
+---------------------------------------------------

--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -37,7 +37,7 @@
   <suppress checks="Header" files="AutoCloseables.java|Collections2.java" />
 
   <!-- no license file in vendored dependencies -->
-  <suppress checks="Header" files="IntObjectMap.java|IntObjectHashMap.java" />
+  <suppress checks="Header" files="IntObjectMap.java|IntObjectHashMap.java|Preconditions.java" />
 
   <!-- Suppress certain checks requiring many code changes, that add little benefit -->
   <suppress checks="NoFinalizer|OverloadMethodsDeclarationOrder|VariableDeclarationUsageDistance" files=".*" />

--- a/memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
+++ b/memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
@@ -1,18 +1,15 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright (C) 2007 The Guava Authors
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.apache.arrow.util;
 

--- a/pom.xml
+++ b/pom.xml
@@ -739,6 +739,11 @@ under the License.
               <file>${maven.multiModuleProjectDirectory}/dev/license/asf-java.license</file>
               <delimiter>package</delimiter>
             </licenseHeader>
+            <excludes>
+              <exclude>**/Preconditions.java</exclude>
+              <exclude>**/IntObjectMap.java</exclude>
+              <exclude>**/IntObjectHashMap.java</exclude>
+            </excludes>
           </java>
         </configuration>
         <executions>

--- a/vector/src/main/java/org/apache/arrow/vector/util/IntObjectHashMap.java
+++ b/vector/src/main/java/org/apache/arrow/vector/util/IntObjectHashMap.java
@@ -1,18 +1,16 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 The Netty Project
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.apache.arrow.vector.util;
 

--- a/vector/src/main/java/org/apache/arrow/vector/util/IntObjectMap.java
+++ b/vector/src/main/java/org/apache/arrow/vector/util/IntObjectMap.java
@@ -1,18 +1,16 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 The Netty Project
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.apache.arrow.vector.util;
 


### PR DESCRIPTION
The files **IntObjectMap.java** and **IntObjectHashMap.java** are sourced from:
https://github.com/netty/netty/tree/netty-4.1.117.Final/common/src/main/templates/io/netty/util/collection/

(Specific types will be generated during the compilation phase, but fundamentally, no change in intellectual property ownership has occurred.)

The Guava code is sourced from:
https://github.com/google/guava/blob/v33.4.0/guava/src/com/google/common/base/Preconditions.java

Given the possibility of changes to the license, the specific version has been noted to help reduce ambiguity.

close #549