### PR TITLE
GH-547: [CI][Docs] Publish docs to https://arrow.apache.org/java/main/ on push

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,3 +38,6 @@ notifications:
   issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org
+publish:
+  whoami: asf-site
+  subdir: java

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -471,6 +471,74 @@ jobs:
         with:
           name: release-html
           path: html.tar.gz
+  public-docs:
+    name: Publish docs
+    # Run only when:
+    # * We push to a branch
+    # * If the target repository is apache/arrow-java:
+    #   * The target branch is main
+    # * Else (fork repositories):
+    #   * All branches
+    #   * We can preview the last pushed content
+    #     at https://${YOUR_GITHUB_ACCOUNT}.github.io/arrow-java/main/
+    if: >-
+      github.event_name == 'push' &&
+        github.ref_type == 'branch' &&
+        ((github.repository == 'apache/arrow-java' && github.ref_name == 'main') ||
+         github.repository != 'apache/arrow-java')
+    needs:
+      - docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: site
+          persist-credentials: true
+      - name: Prepare branch
+        run: |
+          if [ "${GITHUB_REPOSITORY}" = "apache/arrow-java" ]; then
+            BRANCH=asf-site
+          else
+            BRANCH=gh-pages
+          fi
+          echo "BRANCH=${BRANCH}" >> ${GITHUB_ENV}
+
+          cp site/.asf.yaml ./
+          cd site
+          git fetch
+          if ! git switch -c "${BRANCH}" "origin/${BRANCH}"; then
+            git switch --orphan "${BRANCH}"
+          fi
+          touch .nojekyll
+          cp ../.asf.yaml ./
+          git add .nojekyll .asf.yaml
+      - name: Download
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: release-html
+      - name: Extract
+        run: |
+          tar -xf html.tar.gz
+          rm -rf site/main
+          mv html site/main
+          git -C site add main
+          if [ "$(git status --prcelain)" == "" ]; then
+            NEED_PUSH=true
+          else
+            NEED_PUSH=false
+          fi
+          echo "NEED_PUSH=${NEED_PUSH}" >> ${GITHUB_ENV}
+      - name: Push
+        if: env.NEED_PUSH == 'true'
+        run: |
+          cd site
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "Publish documentation (${GITHUB_SHA})"
+          git push origin "${BRANCH}"
   verify:
     name: Verify
     needs:


### PR DESCRIPTION
Fixes #537.

This also enables preview in fork at
`https://${YOUR_GITHUB_ACCOUNT}.github.io/arrow-java/main/` after you enable GitHub Pages on `gh-pages` branch at
`https://github.com/${YOUR_GITHUB_ACCOUNT}/arrow-java/settings/pages`.