### PR TITLE
GH-570: [Docs] Use https://arrow.apache.org/java/ as the official site URL

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@
 
 github:
   description: "Official Java implementation of Apache Arrow"
-  homepage: https://arrow.apache.org/
+  homepage: https://arrow.apache.org/java/
   labels:
     - apache-arrow
     - java


### PR DESCRIPTION
Fixes GH-570.