### PR TITLE
GH-571: [Docs] Fix redirect pattern

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-RedirectMatch permanent "^/$" /current/
+RedirectMatch permanent "^/java/$" /java/current/


### PR DESCRIPTION
Fixes #571.

We need to use `^/java/$` not `^/$` because we deploy our website to `https://.../java/` not `https://.../`.