### PR TITLE
MINOR: Add jbonofre to collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,6 +33,8 @@ github:
   protected_branches:
     main:
       required_linear_history: true
+  collaborators: # Note: the number of collaborators is limited to 10
+    - jbonofre
 notifications:
   commits: commits@arrow.apache.org
   issues_status: issues@arrow.apache.org


### PR DESCRIPTION
We can add collaborator in the `.asf.yaml`. A collaborator can be assigned to GitHub Issue for instance.