### PR TITLE
GH-588: [Release] Increase wait interval in `dev/release/release_rc.sh`

### DIFF
--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -109,13 +109,13 @@ if [ "${RELEASE_SIGN}" -gt 0 ]; then
     if [ -n "${run_id}" ]; then
       break
     fi
-    sleep 60
+    sleep 600
   done
 
   echo "Found GitHub Actions workflow with ID: ${run_id}"
   gh run watch \
     --exit-status "${run_id}" \
-    --interval 60 \
+    --interval 600 \
     --repo "${repository}"
 
   echo "Downloading artifacts from GitHub Releases"


### PR DESCRIPTION
Fixes GH-588.

`release.yml` takes at least 30min now. So 60s wait interval is too short. We can use longer interval to avoid needless API requests.