### PR TITLE
MINOR: Upload release artifacts individually with sleep

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -600,7 +600,12 @@ jobs:
             --prerelease \
             --repo ${GITHUB_REPOSITORY} \
             --title "Apache Arrow Java ${version} RC${rc}" \
-            --verify-tag \
-            artifacts/*/*
+            --verify-tag
+          # GitHub CLI does not respect their own rate limits
+          # https://github.com/cli/cli/issues/9586
+          for artifact in artifacts/*/*; do
+            sleep 1
+            gh release upload ${GITHUB_REF_NAME} $artifact
+          done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to https://github.com/cli/cli/issues/9586, GitHub CLI doesn't respect the GitHub rate limits and GitHub is uninterested in fixing this.