### PR TITLE
GH-499: Require PR labels for changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,7 @@
-<!-- Thank you for opening a new pull request. -->
-<!-- Please add one or more of these PR labels as appropriate: bug-fix, enhancement, documentation, dependencies, chore. -->
-<!-- Please describe your changes: -->
+## What's Changed
 
-<!-- If there are breaking changes, please uncomment this line: -->
-<!-- **This contains breaking changes.** -->
+Please fill in a description of the changes here.
 
-<!-- Please link any issues with closing keywords, e.g. "Closes #NNN". ->
+**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->
+
+Closes #NNN.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- Thank you for opening a new pull request. -->
+<!-- Please add one or more of these PR labels as appropriate: bug-fix, enhancement, documentation, dependencies, chore. -->
+<!-- Please describe your changes: -->
+
+<!-- If there are breaking changes, please uncomment this line: -->
+<!-- **This contains breaking changes.** -->
+
+<!-- Please link any issues with closing keywords, e.g. "Closes #NNN". ->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,7 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-.gitmodules
-.github/pull_request_template.md
-dataset/src/test/resources/data/student.csv
-docs/Makefile
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+
+    - title: New Features and Enhancements
+      labels:
+        - enhancement
+
+    - title: Bug Fixes
+      labels:
+        - bug-fix
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/dev_pr.js
+++ b/.github/workflows/dev_pr.js
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+module.exports = {
+    check_title_format: function({core, github, context}) {
+        const title = context.payload.pull_request.title;
+        if (title.startsWith("MINOR: ")) {
+            context.log("PR is a minor PR");
+            return {"issue": null};
+        }
+
+        const match = title.match(/^GH-([0-9]+): .*$/);
+        if (match === null) {
+            core.setFailed("Invalid PR title format. Must either be MINOR: or GH-NNN:");
+            return {"issue": null};
+        }
+        return {"issue": parseInt(match[1], 10)};
+    },
+
+    apply_labels: async function({core, github, context}) {
+        const body = (context.payload.pull_request.body || "").split(/\n/g);
+        var has_breaking = false;
+        for (const line of body) {
+            if (line.trim().startsWith("**This contains breaking changes.**")) {
+                has_breaking = true;
+                break;
+            }
+        }
+        if (has_breaking) {
+            console.log("PR has breaking changes");
+            await github.rest.issues.addLabels({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ["breaking-change"],
+            });
+        } else {
+            console.log("PR has no breaking changes");
+        }
+    },
+
+    check_labels: async function({core, github, context}) {
+        const categories = ["bug-fix", "chore", "dependencies", "documentation", "enhancement"];
+        const labels = (context.payload.pull_request.labels || []);
+        const required = new Set(categories);
+        var found = false;
+
+        for (const label of labels) {
+            console.log(`Found label ${label.name}`);
+            if (required.has(label.name)) {
+                found = true;
+                break;
+            }
+        }
+
+        if (found) {
+            console.log("PR has appropriate label(s)");
+        } else {
+            console.log("PR has is missing label(s)");
+            console.log("Label the PR with one or more of:");
+            for (const label of categories) {
+                console.log(`- ${label}`);
+            }
+            console.log();
+            console.log("Also, add 'breaking-change' if appropriate.");
+            console.log("See CONTRIBUTING.md for details.");
+            core.setFailed("Missing required labels.  See CONTRIBUTING.md");
+        }
+    },
+
+    check_linked_issue: async function({core, github, context, issue}) {
+        console.log(issue);
+        if (issue.issue === null) {
+            console.log("This is a MINOR PR");
+            return;
+        }
+        const expected = `https://github.com/apache/arrow-java/issues/${issue.issue}`;
+
+        const query = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 50) {
+        edges {
+          node {
+            number
+          }
+        }
+      }
+    }
+  }
+}`;
+
+        const result = await github.graphql(query, {
+            owner: context.repo.owner,
+            name: context.repo.repo,
+            number: context.payload.pull_request.number,
+        });
+        const issues = result.repository.pullRequest.closingIssuesReferences.edges;
+        console.log(issues);
+
+        for (const link of issues) {
+            console.log(`PR is linked to ${link.node.number}`);
+            if (link.node.number === issue.issue) {
+                console.log(`Found link to ${expected}`);
+                return;
+            }
+        }
+        console.log(`Did not find link to ${expected}`);
+        core.setFailed("Missing link to issue in title");
+    },
+};

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Dev PR
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - review_requested
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-label:
+    name: "Ensure PR format"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure PR is labeled
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          if ! echo "$LABELS" | jq -e '.[] | select(.name | IN("bug-fix", "dependencies", "enhancement")) | .name'; then
+            echo "Label the PR with one or more of:"
+            echo "- bug-fix"
+            echo "- dependencies"
+            echo "- enhancement"
+            echo
+            echo "Also, add 'breaking-change' if appropriate."
+            exit 1
+          else
+            echo "Pull request is labeled properly!"
+          fi
+
+      - name: Ensure PR title format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -x
+          if echo $TITLE | grep --extended-regexp "^MINOR: .*$" >/dev/null; then
+            echo "This is a MINOR PR."
+          elif echo $TITLE | grep --extended-regexp "^GH-[0-9]+: .*$" >/dev/null; then
+            echo "This is a normal PR."
+          else
+            echo "PR title format is incorrect. Please see CONTRIBUTING.md."
+            exit 1
+          fi

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -41,32 +41,36 @@ jobs:
     name: "Ensure PR format"
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure PR is labeled
-        env:
-          LABELS: ${{ toJson(github.event.pull_request.labels) }}
-        run: |
-          if ! echo "$LABELS" | jq -e '.[] | select(.name | IN("bug-fix", "dependencies", "enhancement")) | .name'; then
-            echo "Label the PR with one or more of:"
-            echo "- bug-fix"
-            echo "- dependencies"
-            echo "- enhancement"
-            echo
-            echo "Also, add 'breaking-change' if appropriate."
-            exit 1
-          else
-            echo "Pull request is labeled properly!"
-          fi
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Ensure PR title format
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          set -x
-          if echo $TITLE | grep --extended-regexp "^MINOR: .*$" >/dev/null; then
-            echo "This is a MINOR PR."
-          elif echo $TITLE | grep --extended-regexp "^GH-[0-9]+: .*$" >/dev/null; then
-            echo "This is a normal PR."
-          else
-            echo "PR title format is incorrect. Please see CONTRIBUTING.md."
-            exit 1
-          fi
+        id: title-format
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const scripts = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr.js`);
+            return scripts.check_title_format({core, github, context});
+
+      - name: Label PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const scripts = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr.js`);
+            await scripts.apply_labels({core, github, context});
+
+      - name: Ensure PR is labeled
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const scripts = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr.js`);
+            await scripts.check_labels({core, github, context});
+
+      - name: Ensure PR is linked to an issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const scripts = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr.js`);
+            await scripts.check_linked_issue({core, github, context, issue: ${{ steps.title-format.outputs.result }}});

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -42,7 +42,7 @@ jobs:
     name: "Ensure PR format"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -35,6 +35,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   pr-label:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,11 @@ existing Arrow issues in [GitHub](https://github.com/apache/arrow-java/issues).
 
 - Create a GitHub issue and submit your changes as a GitHub Pull Request.
 - [Reference the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) in your PR description.
-- Add one or more of the labels "bug-fix", "dependencies", and "enhancement" to your PR as appropriate.
+- Add one or more of the labels "bug-fix", "chore", "dependencies", "documentation", and "enhancement" to your PR as appropriate.
   - "bug-fix" is for PRs that fix a bug.
-  - "dependencies" is for PRs that upgrade a dependency or other administrative work (build system, release process, etc.).
+  - "chore" is for other administrative work (build system, release process, etc.).
+  - "dependencies" is for PRs that upgrade a dependency.  (Usually only used by dependabot.)
+  - "documentation" is for documentation updates.
   - "enhancement" is for PRs that add new features.
 - Add the "breaking-change" label to your PR if there are breaking API changes.
 - Add the PR title. The PR title will be used as the eventual commit message, so please make it descriptive but succinct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,6 @@ GH-42424: Expose Netty server builder in Flight
 Allow direct usage of gRPC APIs for low-level control.
 
 Closes #42424.
-
-Labels: enhancement
 ```
 
 ### Minor Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,6 @@ GH-12345: Document the pull request process
 Explain how to open a pull request and what the title, body, and labels should be.
 
 Closes #12345.
-
-Labels: dependencies
 ```
 
 Example #2:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,38 @@ existing Arrow issues in [GitHub](https://github.com/apache/arrow-java/issues).
 
 ## Did you write a patch that fixes a bug or brings an improvement?
 
-Create a GitHub issue and submit your changes as a GitHub Pull Request.
-Please make sure to [reference the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) in your PR description.
+- Create a GitHub issue and submit your changes as a GitHub Pull Request.
+- [Reference the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) in your PR description.
+- Add one or more of the labels "bug-fix", "dependencies", and "enhancement" to your PR as appropriate.
+  - "bug-fix" is for PRs that fix a bug.
+  - "dependencies" is for PRs that upgrade a dependency or other administrative work (build system, release process, etc.).
+  - "enhancement" is for PRs that add new features.
+- Add the "breaking-change" label to your PR if there are breaking API changes.
+- Add the PR title. The PR title will be used as the eventual commit message, so please make it descriptive but succinct.
+
+Example #1:
+
+```
+GH-12345: Document the pull request process
+
+Explain how to open a pull request and what the title, body, and labels should be.
+
+Closes #12345.
+
+Labels: dependencies
+```
+
+Example #2:
+
+```
+GH-42424: Expose Netty server builder in Flight
+
+Allow direct usage of gRPC APIs for low-level control.
+
+Closes #42424.
+
+Labels: enhancement
+```
 
 ### Minor Fixes
 


### PR DESCRIPTION
- Validate that at least one of certain labels are present on a PR.
- Validate the format of the title.
- Add label for things that are not dependencies but are other chores (release/build work).
- Add label for documentation updates.
- Validate that a PR titled `GH-499` is actually linked to issue `#499` by poking the GitHub API.
- Add the GitHub config to use these labels for changelog generation.

Closes #499.