### PR TITLE
GH-601: [Gandiva] Synchronize some methods on the Projector

### DIFF
--- a/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
+++ b/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
@@ -188,7 +188,7 @@ public class Projector {
    * @param configurationId Custom configuration created through config builder.
    * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
    */
-  public static Projector make(
+  public static synchronized Projector make(
       Schema schema,
       List<ExpressionTree> exprs,
       SelectionVectorType selectionVectorType,
@@ -314,7 +314,7 @@ public class Projector {
         outColumns);
   }
 
-  private void evaluate(
+  private synchronized void evaluate(
       int numRows,
       List<ArrowBuf> buffers,
       List<ArrowBuffer> buffersLayout,


### PR DESCRIPTION
### Rationale for this change
Multiple threads can attempt to create the same llvm expression in Gandiva. This isn't allowed with the new JIT compiler, so synchronizing will prevent this scenario.

### What changes are included in this PR?
Synchronize some methods to avoid adding duplicate llvm expressions.

### Are these changes tested?
Yes, through unit tests in Gandiva.

### Are there any user-facing changes?
No.

Closes GH-601