### PR TITLE
GH-603: [Release] Suppress a nested tag warning in `dev/release/release.sh`

### DIFF
--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -45,7 +45,7 @@ esac
 tag="v${version}"
 rc_tag="${tag}-rc${rc}"
 echo "Tagging for release: ${tag}"
-git tag -a -m "${version}" "${tag}" "${rc_tag}"
+git tag -a -m "${version}" "${tag}" "${rc_tag}^{}"
 git push origin "${tag}"
 
 release_id="apache-arrow-java-${version}"


### PR DESCRIPTION
Fixes GH-603.

Message from Git:

    hint: You have created a nested tag. The object referred to by your new tag is
    hint: already a tag. If you meant to tag the object that it points to, use:
    hint:
    hint: 	git tag -f v18.2.0 v18.2.0-rc5^{}
    hint: Disable this message with "git config advice.nestedTag false"