### PR TITLE
GH-623: Cleanup enabling Gandiva tests change

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -107,6 +107,12 @@ jobs:
       - name: Extract source archive
         run: |
           tar -xf apache-arrow-java-*.tar.gz --strip-components=1
+      # We always use the main branch for apache/arrow for now.
+      # Because we want to use
+      # https://github.com/apache/arrow/pull/45114 in
+      # apache/arrow-java. We can revert this workaround once Apache
+      # Arrow 20.0.0 that includes the change released.
+      #
       # - name: Download the latest Apache Arrow C++
       #   if: github.event_name != 'schedule'
       #   run: |
@@ -299,13 +305,13 @@ jobs:
         shell: bash
         run: |
           tar -xf apache-arrow-java-*.tar.gz --strip-components=1
-      # - name: Download the latest Apache Arrow C++
-      #   if: github.event_name != 'schedule'
-      #   shell: bash
-      #   run: |
-      #     ci/scripts/download_cpp.sh
+      - name: Download the latest Apache Arrow C++
+        if: github.event_name != 'schedule'
+        shell: bash
+        run: |
+          ci/scripts/download_cpp.sh
       - name: Checkout Apache Arrow C++
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: apache/arrow


### PR DESCRIPTION
## What's Changed

* Add a comment when we can remove this workaround.
* Remove a needless workaround for Windows.

Closes #623.
