### PR TITLE
GH-657: Set Jna library loading symbol visibility

### DIFF
--- a/gandiva/src/main/java/module-info.java
+++ b/gandiva/src/main/java/module-info.java
@@ -26,4 +26,5 @@ open module org.apache.arrow.gandiva {
   requires org.apache.arrow.memory.core;
   requires org.apache.arrow.vector;
   requires org.slf4j;
+  requires com.sun.jna;
 }

--- a/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
+++ b/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -31,6 +32,9 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
 /** This class handles loading of the jni library, and acts as a bridge for the native functions. */
 class JniLoader {
   private static final String LIBRARY_NAME = "gandiva_jni";
+  
+  private static final int RTLD_GLOBAL = 0x00100;
+  private static final int RTLD_LAZY = 0x00001; 
 
   private static volatile JniLoader INSTANCE;
   private static volatile long defaultConfiguration = 0L;
@@ -69,6 +73,10 @@ class JniLoader {
     final String libraryToLoad =
         LIBRARY_NAME + "/" + getNormalizedArch() + "/" + System.mapLibraryName(LIBRARY_NAME);
     final File libraryFile = moveFileFromJarToTemp(tmpDir, libraryToLoad, LIBRARY_NAME);
+    NativeLibrary.getInstance(
+        libraryFile.getAbsolutePath(),
+        Collections.singletonMap(Library.OPTION_OPEN_FLAGS, new Integer(RTLD_LAZY | RTLD_GLOBAL))
+    );
     System.load(libraryFile.getAbsolutePath());
   }
 

--- a/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
+++ b/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
@@ -18,6 +18,8 @@ package org.apache.arrow.gandiva.evaluator;
 
 import static java.util.UUID.randomUUID;
 
+import com.sun.jna.Library;
+import com.sun.jna.NativeLibrary;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,9 +34,9 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
 /** This class handles loading of the jni library, and acts as a bridge for the native functions. */
 class JniLoader {
   private static final String LIBRARY_NAME = "gandiva_jni";
-  
+
   private static final int RTLD_GLOBAL = 0x00100;
-  private static final int RTLD_LAZY = 0x00001; 
+  private static final int RTLD_LAZY = 0x00001;
 
   private static volatile JniLoader INSTANCE;
   private static volatile long defaultConfiguration = 0L;
@@ -75,8 +77,7 @@ class JniLoader {
     final File libraryFile = moveFileFromJarToTemp(tmpDir, libraryToLoad, LIBRARY_NAME);
     NativeLibrary.getInstance(
         libraryFile.getAbsolutePath(),
-        Collections.singletonMap(Library.OPTION_OPEN_FLAGS, new Integer(RTLD_LAZY | RTLD_GLOBAL))
-    );
+        Collections.singletonMap(Library.OPTION_OPEN_FLAGS, new Integer(RTLD_LAZY | RTLD_GLOBAL)));
     System.load(libraryFile.getAbsolutePath());
   }
 


### PR DESCRIPTION
## What's Changed

Set the Lazy and Global flags when loading the Gandiva library for jni so that system functions are visible to the compiled llvm code.


Closes #657 and https://github.com/apache/arrow/issues/40839.
