### PR TITLE
MINOR: Fix macOS JNI build

### DIFF
--- a/ci/scripts/jni_macos_build.sh
+++ b/ci/scripts/jni_macos_build.sh
@@ -152,7 +152,7 @@ archery linking check-dependencies \
   --allow libgandiva_jni \
   --allow libncurses \
   --allow libobjc \
-  --allow libz \
+  --allow libz3 \
   "arrow_cdata_jni/${normalized_arch}/libarrow_cdata_jni.dylib" \
   "arrow_dataset_jni/${normalized_arch}/libarrow_dataset_jni.dylib" \
   "arrow_orc_jni/${normalized_arch}/libarrow_orc_jni.dylib" \

--- a/ci/scripts/jni_macos_build.sh
+++ b/ci/scripts/jni_macos_build.sh
@@ -152,6 +152,7 @@ archery linking check-dependencies \
   --allow libgandiva_jni \
   --allow libncurses \
   --allow libobjc \
+  --allow libz \
   --allow libz3 \
   "arrow_cdata_jni/${normalized_arch}/libarrow_cdata_jni.dylib" \
   "arrow_dataset_jni/${normalized_arch}/libarrow_dataset_jni.dylib" \


### PR DESCRIPTION
## What's Changed

Update a sanity check in CI that's incorrectly failing the macOS JNI builds.
