### PR TITLE
Preserve nullability information while transfering DecimalVector and Decimal256Vector

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
@@ -566,9 +566,7 @@ public final class Decimal256Vector extends BaseFixedWidthVector
     Decimal256Vector to;
 
     public TransferImpl(String ref, BufferAllocator allocator) {
-      to =
-          new Decimal256Vector(
-              ref, allocator, Decimal256Vector.this.precision, Decimal256Vector.this.scale);
+      to = new Decimal256Vector(ref, Decimal256Vector.this.field.getFieldType(), allocator);
     }
 
     public TransferImpl(Field field, BufferAllocator allocator) {

--- a/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -564,8 +564,7 @@ public final class DecimalVector extends BaseFixedWidthVector
     DecimalVector to;
 
     public TransferImpl(String ref, BufferAllocator allocator) {
-      to =
-          new DecimalVector(ref, allocator, DecimalVector.this.precision, DecimalVector.this.scale);
+      to = new DecimalVector(ref, DecimalVector.this.field.getFieldType(), allocator);
     }
 
     public TransferImpl(Field field, BufferAllocator allocator) {

--- a/vector/src/test/java/org/apache/arrow/vector/TestDecimal256Vector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestDecimal256Vector.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -373,6 +374,33 @@ public class TestDecimal256Vector {
     // Field inside a new vector created by reusing a field should be the same in memory as the
     // original field.
     assertSame(fromVector.getField(), toVector.getField());
+  }
+
+  @Test
+  public void testGetTransferPairWithoutField() {
+    final Decimal256Vector fromVector = new Decimal256Vector("decimal", allocator, 10, scale);
+    final TransferPair transferPair =
+        fromVector.getTransferPair(fromVector.getField().getName(), allocator);
+    final Decimal256Vector toVector = (Decimal256Vector) transferPair.getTo();
+    // A new Field created inside a new vector should reuse the field type (should be the same in
+    // memory as the original Field's field type).
+    assertSame(fromVector.getField().getFieldType(), toVector.getField().getFieldType());
+  }
+
+  @Test
+  public void testGetTransferPairWithoutFieldNonNullable() {
+    final FieldType decimal256NonNullableType =
+        new FieldType(
+            false, new ArrowType.Decimal(10, scale, Decimal256Vector.TYPE_WIDTH * 8), null);
+    final Decimal256Vector fromVector =
+        new Decimal256Vector("decimal", decimal256NonNullableType, allocator);
+    final TransferPair transferPair =
+        fromVector.getTransferPair(fromVector.getField().getName(), allocator);
+    final Decimal256Vector toVector = (Decimal256Vector) transferPair.getTo();
+    // A new Field created inside a new vector should reuse the field type (should be the same in
+    // memory as the original Field's field type).
+    assertSame(fromVector.getField().getFieldType(), toVector.getField().getFieldType());
+    assertSame(decimal256NonNullableType, toVector.getField().getFieldType());
   }
 
   private void verifyWritingArrowBufWithBigEndianBytes(

--- a/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -369,6 +370,31 @@ public class TestDecimalVector {
     // Field inside a new vector created by reusing a field should be the same in memory as the
     // original field.
     assertSame(fromVector.getField(), toVector.getField());
+  }
+
+  @Test
+  public void testGetTransferPairWithoutField() {
+    final DecimalVector fromVector = new DecimalVector("decimal", allocator, 10, scale);
+    final TransferPair transferPair =
+        fromVector.getTransferPair(fromVector.getField().getName(), allocator);
+    final DecimalVector toVector = (DecimalVector) transferPair.getTo();
+    // A new Field created inside a new vector should reuse the field type (should be the same in
+    // memory as the original Field's field type).
+    assertSame(fromVector.getField().getFieldType(), toVector.getField().getFieldType());
+  }
+
+  @Test
+  public void testGetTransferPairWithoutFieldNonNullable() {
+    final FieldType decimalNonNullableType =
+        new FieldType(false, new ArrowType.Decimal(10, scale), null);
+    final DecimalVector fromVector =
+        new DecimalVector("decimal", decimalNonNullableType, allocator);
+    final TransferPair transferPair =
+        fromVector.getTransferPair(fromVector.getField().getName(), allocator);
+    final DecimalVector toVector = (DecimalVector) transferPair.getTo();
+    // A new Field created inside a new vector should reuse the field type (should be the same in
+    // memory as the original Field's field type).
+    assertSame(fromVector.getField().getFieldType(), toVector.getField().getFieldType());
   }
 
   private void verifyWritingArrowBufWithBigEndianBytes(


### PR DESCRIPTION
## What's Changed

This PR proposes to use the "from" `ValueVector`'s field while transferring `DecimalVector` and `Decimal256Vector` to preserve nullability information. This is to have similar behavior with all the other primitive value vectors. Note that the `FieldType` of the value vector has nullability information.

Closes #692 .
