### PR TITLE
GH-704: Fix initialization of offset buffer when exporting VarChar vectors through C Data Interface

### DIFF
--- a/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -79,7 +79,6 @@ import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
-import org.apache.arrow.vector.VariableWidthVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ViewVarBinaryVector;
 import org.apache.arrow.vector.ViewVarCharVector;
@@ -185,7 +184,8 @@ public class RoundtripTest {
           String.format("expected %s but was %s", clazz, imported.getClass()));
       result = VectorEqualsVisitor.vectorEquals(vector, imported);
 
-      if (imported instanceof BaseVariableWidthVector || imported instanceof BaseLargeVariableWidthVector) {
+      if (imported instanceof BaseVariableWidthVector
+          || imported instanceof BaseLargeVariableWidthVector) {
         ArrowBuf offsetBuffer = imported.getOffsetBuffer();
         assertTrue(offsetBuffer.capacity() > 0);
         assertEquals(0, offsetBuffer.getInt(0));
@@ -614,7 +614,6 @@ public class RoundtripTest {
   @Test
   public void testEmptyVarCharVector() {
     try (final VarCharVector vector = new VarCharVector("v", allocator)) {
-      setVector(vector, new String[] {});
       assertTrue(roundtrip(vector, VarCharVector.class));
     }
   }
@@ -655,7 +654,6 @@ public class RoundtripTest {
   @Test
   public void testEmptyLargeVarCharVector() {
     try (final LargeVarCharVector vector = new LargeVarCharVector("v", allocator)) {
-      setVector(vector, new String[] {});
       assertTrue(roundtrip(vector, LargeVarCharVector.class));
     }
   }

--- a/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -496,7 +496,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
   private ArrowBuf allocateOffsetBuffer(final long size) {
     ArrowBuf offsetBuffer = allocator.buffer(size);
     offsetBuffer.readerIndex(0);
-    initOffsetBuffer();
+    offsetBuffer.setZero(0, offsetBuffer.capacity());
     return offsetBuffer;
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -514,7 +514,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     final int curSize = (int) size;
     ArrowBuf offsetBuffer = allocator.buffer(curSize);
     offsetBuffer.readerIndex(0);
-    initOffsetBuffer();
+    offsetBuffer.setZero(0, offsetBuffer.capacity());
     return offsetBuffer;
   }
 


### PR DESCRIPTION
## What's Changed

This patch fixes the initialization of offset buffers when exporting variable width arrays through Arrow C Data Interface. The original code incorrectly mess up with the member `this.offsetBuffer` while we should actually initialize the newly allocated offsetBuffer. I think the diff itself will be quite self-explanatory.

Closes #704 and probably #88 .
