### PR TITLE
MINOR: Fix JNI code after upstream DCHECK change

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -261,6 +261,10 @@ jobs:
           # bundled Protobuf.
           brew uninstall protobuf
 
+          # We need Flatbuffers 24, not the latest version
+          brew uninstall flatbuffers || :
+          brew install flatbuffers@24.3.6 || :
+
           brew bundle --file=Brewfile
       - name: Prepare ccache
         run: |

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -262,8 +262,9 @@ jobs:
           brew uninstall protobuf
 
           # We need Flatbuffers 24, not the latest version
-          brew uninstall flatbuffers || :
-          brew install flatbuffers@24.3.6 || :
+          # Homebrew does not offer older versions, so remove the Homebrew
+          # package and rely on Arrow using a bundled version instead
+          brew uninstall flatbuffers
 
           brew bundle --file=Brewfile
       - name: Prepare ccache

--- a/dataset/src/main/cpp/jni_util.cc
+++ b/dataset/src/main/cpp/jni_util.cc
@@ -187,7 +187,7 @@ ReservationListenableMemoryPool::~ReservationListenableMemoryPool() {}
 std::string Describe(JNIEnv* env, jthrowable t) {
   jclass describer_class =
       env->FindClass("org/apache/arrow/dataset/jni/JniExceptionDescriber");
-  DCHECK_NE(describer_class, nullptr);
+  ARROW_DCHECK_NE(describer_class, nullptr);
   jmethodID describe_method = env->GetStaticMethodID(
       describer_class, "describe", "(Ljava/lang/Throwable;)Ljava/lang/String;");
   std::string description = JStringToCString(
@@ -197,7 +197,7 @@ std::string Describe(JNIEnv* env, jthrowable t) {
 
 bool IsErrorInstanceOf(JNIEnv* env, jthrowable t, std::string class_name) {
   jclass java_class = env->FindClass(class_name.c_str());
-  DCHECK_NE(java_class, nullptr) << "Could not find Java class " << class_name;
+  ARROW_DCHECK_NE(java_class, nullptr) << "Could not find Java class " << class_name;
   return env->IsInstanceOf(t, java_class);
 }
 

--- a/gandiva/src/main/cpp/expression_registry_helper.cc
+++ b/gandiva/src/main/cpp/expression_registry_helper.cc
@@ -138,7 +138,7 @@ void ArrowToProtobuf(DataTypePtr type, gandiva::types::ExtGandivaType* gandiva_d
     default:
       // un-supported types. test ensures that
       // when one of these are added build breaks.
-      DCHECK(false);
+      ARROW_DCHECK(false);
   }
 }
 

--- a/gandiva/src/main/cpp/jni_common.cc
+++ b/gandiva/src/main/cpp/jni_common.cc
@@ -751,7 +751,7 @@ Status JavaResizableBuffer::Resize(const int64_t new_size, bool shrink_to_fit) {
   }
 
   RETURN_NOT_OK(Reserve(new_size));
-  DCHECK_GE(capacity_, new_size);
+  ARROW_DCHECK_GE(capacity_, new_size);
   size_ = new_size;
   return Status::OK();
 }


### PR DESCRIPTION
## What's Changed

Upstream renamed the public DCHECK macros to ARROW_DCHECK (https://github.com/apache/arrow/pull/46015)