### PR TITLE
GH-709: Correct length calculation of value buffers of variable-sized arrays

### DIFF
--- a/c/src/main/java/org/apache/arrow/c/BufferImportTypeVisitor.java
+++ b/c/src/main/java/org/apache/arrow/c/BufferImportTypeVisitor.java
@@ -228,9 +228,8 @@ class BufferImportTypeVisitor implements ArrowType.ArrowTypeVisitor<List<ArrowBu
           type,
           start,
           end);
-      final int len = end - start;
       offsets.getReferenceManager().retain();
-      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, len));
+      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, end));
     }
   }
 
@@ -279,9 +278,8 @@ class BufferImportTypeVisitor implements ArrowType.ArrowTypeVisitor<List<ArrowBu
           type,
           start,
           end);
-      final long len = end - start;
       offsets.getReferenceManager().retain();
-      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, len));
+      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, end));
     }
   }
 
@@ -296,9 +294,8 @@ class BufferImportTypeVisitor implements ArrowType.ArrowTypeVisitor<List<ArrowBu
           type,
           start,
           end);
-      final int len = end - start;
       offsets.getReferenceManager().retain();
-      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, len));
+      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, end));
     }
   }
 
@@ -320,9 +317,8 @@ class BufferImportTypeVisitor implements ArrowType.ArrowTypeVisitor<List<ArrowBu
           type,
           start,
           end);
-      final long len = end - start;
       offsets.getReferenceManager().retain();
-      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, len));
+      return Arrays.asList(maybeImportBitmap(type), offsets, importData(type, end));
     }
   }
 


### PR DESCRIPTION
## What's Changed

For variable-size binary layout arrays, BufferImportTypeVisitor currently derives the length of the value buffer by calculating the difference between the last and first offset. When the first offset is not zero, this is actually incorrect and leads to out of bounds errors when attempting to read values from the imported array.

Instead, BufferImportTypeVisitor should simply use the last offset value as the length of the value buffer. This PR makes that change.

Just FYI, I bumped into this issue when attempting to import an array originating from DataFusion. A test query of the form `SELECT column1 FROM VALUES ('a'), ('b'), ('c'), ('d') LIMIT 2 OFFSET 1;` returns a slice of the full set of values. The values buffer contains all the original values, and the offsets buffer contains 1 and 2 as values to handle the offset from the query.

Closes #709 .
