### PR TITLE
GH-708: Enable GitHub discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,12 +29,17 @@ github:
     rebase: false
     squash: true
   features:
+    discussions: true
     issues: true
+  labels:
+    - arrow
+    - java
   protected_branches:
     main:
       required_linear_history: true
 notifications:
   commits: commits@arrow.apache.org
+  discussions: user@arrow.apache.org
   issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,9 +31,6 @@ github:
   features:
     discussions: true
     issues: true
-  labels:
-    - arrow
-    - java
   protected_branches:
     main:
       required_linear_history: true


### PR DESCRIPTION
## What's Changed

Enable GitHub Discussions like other Arrow repositories.

Fixes #708.

