### PR TITLE
MINOR: Revert "MINOR: Bump io.netty:netty-bom from 4.1.119.Final to 4.2.0.Final (#700)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ under the License.
     <dep.junit.jupiter.version>5.12.2</dep.junit.jupiter.version>
     <dep.slf4j.version>2.0.17</dep.slf4j.version>
     <dep.guava-bom.version>33.4.8-jre</dep.guava-bom.version>
-    <dep.netty-bom.version>4.2.1.Final</dep.netty-bom.version>
+    <dep.netty-bom.version>4.1.119.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.71.0</dep.grpc-bom.version>
     <dep.protobuf-bom.version>4.30.2</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.18.3</dep.jackson-bom.version>


### PR DESCRIPTION
As discussed, better to stay with Netty 4.1.x for now (regarding gRPC).