### PR TITLE
MINOR: add missing SOURCE_DIR in dev/release/release.sh

### DIFF
--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -19,6 +19,8 @@
 
 set -eu
 
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <rc>"
   echo " e.g.: $0 19.0.1 1"


### PR DESCRIPTION
## What's Changed

`dev/release/release.sh` requires `SOURCE_DIR` to locate `.env` but it is missing.