### PR TITLE
fix get length of byte[] in TryCopyLastError

### DIFF
--- a/c/src/main/cpp/jni_wrapper.cc
+++ b/c/src/main/cpp/jni_wrapper.cc
@@ -205,8 +205,9 @@ void TryCopyLastError(JNIEnv* env, InnerPrivateData* private_data) {
     return;
   }
 
+  jsize error_bytes_len = env->GetArrayLength(arr);
   char* error_str = reinterpret_cast<char*>(error_bytes);
-  private_data->last_error_ = std::string(error_str, std::strlen(error_str));
+  private_data->last_error_ = std::string(error_str, error_bytes_len);
 
   env->ReleaseByteArrayElements(arr, error_bytes, JNI_ABORT);
 }


### PR DESCRIPTION
## What's Changed

Please fill in a description of the changes here.

We should get the length of byte[] by `GetArrayLength` but not `strlen` which may cause invalid memory access.

Closes #759 .
