### PR TITLE
GH-52: Make RangeEqualsVisitor of RunEndEncodedVector more efficient

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -286,8 +286,9 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
       int leftPhysicalIndex = leftIterator.getRunIndex();
       int rightPhysicalIndex = rightIterator.getRunIndex();
 
-      if (leftIterator.getRunLength() != rightIterator.getRunLength() || !leftValuesVector.accept(
-          innerVisitor, new Range(leftPhysicalIndex, rightPhysicalIndex, 1))) {
+      if (leftIterator.getRunLength() != rightIterator.getRunLength()
+          || !leftValuesVector.accept(
+              innerVisitor, new Range(leftPhysicalIndex, rightPhysicalIndex, 1))) {
         return false;
       }
     }

--- a/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -272,16 +272,17 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     RunEndEncodedVector rightVector = (RunEndEncodedVector) right;
 
     final RunEndEncodedVector.RangeIterator leftIterator =
-        new RangeIterator(leftVector, range.getLeftStart(), range.getLength());
+        new RunEndEncodedVector.RangeIterator(leftVector, range.getLeftStart(), range.getLength());
     final RunEndEncodedVector.RangeIterator rightIterator =
-        new RangeIterator(rightVector, range.getRightStart(), range.getLength());
+        new RunEndEncodedVector.RangeIterator(
+            rightVector, range.getRightStart(), range.getLength());
 
     FieldVector leftValuesVector = leftVector.getValuesVector();
     FieldVector rightValuesVector = rightVector.getValuesVector();
 
     RangeEqualsVisitor innerVisitor = createInnerVisitor(leftValuesVector, rightValuesVector, null);
 
-    while (leftIterator.nextRun() | rightIterator.nextRun()) {
+    while (nextRun(leftIterator, rightIterator)) {
       int leftPhysicalIndex = leftIterator.getRunIndex();
       int rightPhysicalIndex = rightIterator.getRunIndex();
 
@@ -295,7 +296,13 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
       }
     }
 
-    return true;
+    return leftIterator.isEnd() && rightIterator.isEnd();
+  }
+
+  private static boolean nextRun(RangeIterator leftIterator, RangeIterator rightIterator) {
+    boolean left = leftIterator.nextRun();
+    boolean right = rightIterator.nextRun();
+    return left && right;
   }
 
   protected RangeEqualsVisitor createInnerVisitor(

--- a/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -286,12 +286,8 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
       int leftPhysicalIndex = leftIterator.getRunIndex();
       int rightPhysicalIndex = rightIterator.getRunIndex();
 
-      if (leftValuesVector.accept(
+      if (leftIterator.getRunLength() != rightIterator.getRunLength() || !leftValuesVector.accept(
           innerVisitor, new Range(leftPhysicalIndex, rightPhysicalIndex, 1))) {
-        if (leftIterator.getRunLength() != rightIterator.getRunLength()) {
-          return false;
-        }
-      } else {
         return false;
       }
     }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/RunEndEncodedVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/RunEndEncodedVector.java
@@ -830,6 +830,14 @@ public class RunEndEncodedVector extends BaseValueVector implements FieldVector 
     private int runEnd;
     private int logicalPos;
 
+    /**
+     * Constructs a new RangeIterator for iterating over a range of values in a RunEndEncodedVector.
+     *
+     * @param runEndEncodedVector The vector to iterate over
+     * @param startIndex The logical start index of the range (inclusive)
+     * @param length The number of values to include in the range
+     * @throws IllegalArgumentException if startIndex is negative or (startIndex + length) exceeds vector bounds
+     */
     public RangeIterator(RunEndEncodedVector runEndEncodedVector, int startIndex, int length) {
       int rangeEnd = startIndex + length;
       Preconditions.checkArgument(
@@ -847,6 +855,11 @@ public class RunEndEncodedVector extends BaseValueVector implements FieldVector 
       this.logicalPos = -1;
     }
 
+    /**
+     * Advances to the next run in the range.
+     *
+     * @return true if there is another run available, false if iteration has completed
+     */
     public boolean nextRun() {
       logicalPos = runEnd;
       if (logicalPos >= rangeEnd) {
@@ -861,6 +874,11 @@ public class RunEndEncodedVector extends BaseValueVector implements FieldVector 
       runEnd = (int) ((BaseIntVector) runEndEncodedVector.runEndsVector).getValueAsLong(runIndex);
     }
 
+    /**
+     * Advances to the next value in the range.
+     *
+     * @return true if there is another value available, false if iteration has completed
+     */
     public boolean nextValue() {
       logicalPos++;
       if (logicalPos >= rangeEnd) {
@@ -872,14 +890,29 @@ public class RunEndEncodedVector extends BaseValueVector implements FieldVector 
       return true;
     }
 
+    /**
+     * Gets the current run index (physical position in the run-ends vector).
+     *
+     * @return the current run index
+     */
     public int getRunIndex() {
       return runIndex;
     }
 
+    /**
+     * Gets the length of the current run within the iterator's range.
+     *
+     * @return the number of remaining values in current run within the iterator's range
+     */
     public int getRunLength() {
       return Math.min(runEnd, rangeEnd) - logicalPos;
     }
 
+    /**
+     * Checks if iteration has completed.
+     *
+     * @return true if all values in the range have been processed, false otherwise
+     */
     public boolean isEnd() {
       return logicalPos >= rangeEnd;
     }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/RunEndEncodedVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/RunEndEncodedVector.java
@@ -836,7 +836,8 @@ public class RunEndEncodedVector extends BaseValueVector implements FieldVector 
      * @param runEndEncodedVector The vector to iterate over
      * @param startIndex The logical start index of the range (inclusive)
      * @param length The number of values to include in the range
-     * @throws IllegalArgumentException if startIndex is negative or (startIndex + length) exceeds vector bounds
+     * @throws IllegalArgumentException if startIndex is negative or (startIndex + length) exceeds
+     *     vector bounds
      */
     public RangeIterator(RunEndEncodedVector runEndEncodedVector, int startIndex, int length) {
       int rangeEnd = startIndex + length;

--- a/vector/src/test/java/org/apache/arrow/vector/TestRunEndEncodedVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestRunEndEncodedVector.java
@@ -148,12 +148,18 @@ public class TestRunEndEncodedVector {
     assertTrue(
         constantVector.accept(
             new RangeEqualsVisitor(constantVector, constantVector), new Range(1, 2, 13)));
-    assertFalse(
-        constantVector.accept(
-            new RangeEqualsVisitor(constantVector, constantVector), new Range(1, 10, 10)));
-    assertFalse(
-        constantVector.accept(
-            new RangeEqualsVisitor(constantVector, constantVector), new Range(10, 1, 10)));
+
+    // throws exception if the range end is out the bound of the vector
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            constantVector.accept(
+                new RangeEqualsVisitor(constantVector, constantVector), new Range(1, 10, 10)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            constantVector.accept(
+                new RangeEqualsVisitor(constantVector, constantVector), new Range(10, 1, 10)));
 
     // Create REE vector representing: [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5].
     RunEndEncodedVector reeVector =


### PR DESCRIPTION
## What's Changed

Avoid doing a binary search on every step to make the RangeEqualsVisitor of RunEndEncodedVector more efficient.

Closes #52 .
