### PR TITLE
MINOR: Fix broken Linux JNI build

### DIFF
--- a/ci/scripts/jni_build.sh
+++ b/ci/scripts/jni_build.sh
@@ -50,11 +50,15 @@ Darwin)
 esac
 
 : "${ARROW_JAVA_BUILD_TESTS:=${ARROW_BUILD_TESTS:-ON}}"
+: "${ARROW_VCPKG:=OFF}"
 : "${CMAKE_BUILD_TYPE:=release}"
 read -ra EXTRA_CMAKE_OPTIONS <<<"${JAVA_JNI_CMAKE_ARGS:-}"
+# Must set ARROW_VCPKG because upstream Findutf8proc.cmake checks that to
+# determine what to do
 cmake \
   -S "${source_dir}" \
   -B "${build_dir}" \
+  -DARROW_VCPKG="${ARROW_VCPKG}" \
   -DARROW_JAVA_JNI_ENABLE_DATASET="${ARROW_DATASET:-OFF}" \
   -DARROW_JAVA_JNI_ENABLE_GANDIVA="${ARROW_GANDIVA:-OFF}" \
   -DARROW_JAVA_JNI_ENABLE_ORC="${ARROW_ORC:-OFF}" \

--- a/ci/scripts/jni_manylinux_build.sh
+++ b/ci/scripts/jni_manylinux_build.sh
@@ -71,6 +71,7 @@ export ARROW_GANDIVA
 export ARROW_ORC
 : "${ARROW_PARQUET:=ON}"
 : "${ARROW_S3:=ON}"
+export ARROW_VCPKG=ON # influences jni_build.sh
 : "${CMAKE_BUILD_TYPE:=release}"
 : "${CMAKE_UNITY_BUILD:=ON}"
 : "${VCPKG_ROOT:=/opt/vcpkg}"

--- a/gandiva/src/main/cpp/jni_common.cc
+++ b/gandiva/src/main/cpp/jni_common.cc
@@ -221,7 +221,7 @@ DataTypePtr ProtoTypeToDataType(const gandiva::types::ExtGandivaType& ext_type) 
       return arrow::date64();
     case gandiva::types::DECIMAL:
       // TODO: error handling
-      return arrow::decimal(ext_type.precision(), ext_type.scale());
+      return arrow::decimal128(ext_type.precision(), ext_type.scale());
     case gandiva::types::TIME32:
       return ProtoTypeToTime32(ext_type);
     case gandiva::types::TIME64:


### PR DESCRIPTION
## What's Changed

I think this was due to apache/arrow@1229ceddd512aa5b3a601019ee3b4bae28cfa3e6.

We need to explicitly set ARROW_VCPKG=ON for Linux builds so that Findutf8proc.cmake does the right thing.
