### PR TITLE
GH-768: Use apache/arrow-js for JS in integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: java
+      - name: Checkout Arrow JavaScript
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: apache/arrow-js
+          path: js
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -199,6 +204,7 @@ jobs:
             -e ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS=java \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
+            -e ARCHERY_INTEGRATION_WITH_JS=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration


### PR DESCRIPTION
## What's Changed

`js/` in apache/arrow moved to apache/arrow-js. So let's use apache/arrow-js for JS.

Closes #768.
