### PR TITLE
GH-774: Consoliate `BitVectorHelper.getValidityBufferSize` and `BaseValueVector.getValidityBufferSizeFromCount`

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -110,11 +110,6 @@ public abstract class BaseValueVector implements ValueVector {
     return buffer;
   }
 
-  /* number of bytes for the validity buffer for the given valueCount */
-  protected static int getValidityBufferSizeFromCount(final int valueCount) {
-    return DataSizeRoundingUtil.divideBy8Ceil(valueCount);
-  }
-
   /* round up bytes for the validity buffer for the given valueCount */
   private static long roundUp8ForValidityBuffer(long valueCount) {
     return ((valueCount + 63) >> 6) << 3;

--- a/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.apache.arrow.vector.util.DataSizeRoundingUtil.roundUpToMultipleOf16;
 
 import java.nio.ByteBuffer;

--- a/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.ArrowBuf;

--- a/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -135,11 +135,11 @@ public class BitVectorHelper {
   public static ArrowBuf setValidityBit(
       ArrowBuf validityBuffer, BufferAllocator allocator, int valueCount, int index, int value) {
     if (validityBuffer == null) {
-      validityBuffer = allocator.buffer(getValidityBufferSize(valueCount));
+      validityBuffer = allocator.buffer(getValidityBufferSizeFromCount(valueCount));
     }
     setValidityBit(validityBuffer, index, value);
     if (index == (valueCount - 1)) {
-      validityBuffer.writerIndex(getValidityBufferSize(valueCount));
+      validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
     }
 
     return validityBuffer;
@@ -165,7 +165,7 @@ public class BitVectorHelper {
    * @param valueCount number of elements in the vector
    * @return buffer size
    */
-  public static int getValidityBufferSize(int valueCount) {
+  public static int getValidityBufferSizeFromCount(int valueCount) {
     return DataSizeRoundingUtil.divideBy8Ceil(valueCount);
   }
 
@@ -182,7 +182,7 @@ public class BitVectorHelper {
       return 0;
     }
     int count = 0;
-    final int sizeInBytes = getValidityBufferSize(valueCount);
+    final int sizeInBytes = getValidityBufferSizeFromCount(valueCount);
     // If value count is not a multiple of 8, then calculate number of used bits in the last byte
     final int remainder = valueCount % 8;
     final int fullBytesCount = remainder == 0 ? sizeInBytes : sizeInBytes - 1;
@@ -233,7 +233,7 @@ public class BitVectorHelper {
     if (valueCount == 0) {
       return true;
     }
-    final int sizeInBytes = getValidityBufferSize(valueCount);
+    final int sizeInBytes = getValidityBufferSizeFromCount(valueCount);
 
     // boundary check
     validityBuffer.checkBytes(0, sizeInBytes);
@@ -325,7 +325,7 @@ public class BitVectorHelper {
         sourceValidityBuffer == null || sourceValidityBuffer.capacity() == 0;
     if (isValidityBufferNull
         && (fieldNode.getNullCount() == 0 || fieldNode.getNullCount() == valueCount)) {
-      newBuffer = allocator.buffer(getValidityBufferSize(valueCount));
+      newBuffer = allocator.buffer(getValidityBufferSizeFromCount(valueCount));
       newBuffer.setZero(0, newBuffer.capacity());
       if (fieldNode.getNullCount() != 0) {
         /* all NULLs */

--- a/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkArgument;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 
 import java.util.ArrayList;

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkArgument;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkArgument;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkArgument;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkArgument;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector.complex;
 
 import static org.apache.arrow.util.Preconditions.checkArgument;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;

--- a/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector.complex;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkNotNull;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,7 +90,7 @@ public class StructVector extends NonNullableStructVector
     super(name, checkNotNull(allocator), fieldType, callBack);
     this.validityBuffer = allocator.getEmpty();
     this.validityAllocationSizeInBytes =
-        BitVectorHelper.getValidityBufferSize(BaseValueVector.INITIAL_VALUE_ALLOCATION);
+        getValidityBufferSizeFromCount(BaseValueVector.INITIAL_VALUE_ALLOCATION);
   }
 
   /**
@@ -118,7 +119,7 @@ public class StructVector extends NonNullableStructVector
         allowConflictPolicyChanges);
     this.validityBuffer = allocator.getEmpty();
     this.validityAllocationSizeInBytes =
-        BitVectorHelper.getValidityBufferSize(BaseValueVector.INITIAL_VALUE_ALLOCATION);
+        getValidityBufferSizeFromCount(BaseValueVector.INITIAL_VALUE_ALLOCATION);
   }
 
   /**
@@ -132,7 +133,7 @@ public class StructVector extends NonNullableStructVector
     super(field, checkNotNull(allocator), callBack);
     this.validityBuffer = allocator.getEmpty();
     this.validityAllocationSizeInBytes =
-        BitVectorHelper.getValidityBufferSize(BaseValueVector.INITIAL_VALUE_ALLOCATION);
+        getValidityBufferSizeFromCount(BaseValueVector.INITIAL_VALUE_ALLOCATION);
   }
 
   /**
@@ -153,7 +154,7 @@ public class StructVector extends NonNullableStructVector
     super(field, checkNotNull(allocator), callBack, conflictPolicy, allowConflictPolicyChanges);
     this.validityBuffer = allocator.getEmpty();
     this.validityAllocationSizeInBytes =
-        BitVectorHelper.getValidityBufferSize(BaseValueVector.INITIAL_VALUE_ALLOCATION);
+        getValidityBufferSizeFromCount(BaseValueVector.INITIAL_VALUE_ALLOCATION);
   }
 
   @Override
@@ -182,7 +183,7 @@ public class StructVector extends NonNullableStructVector
 
   private void setReaderAndWriterIndex() {
     validityBuffer.readerIndex(0);
-    validityBuffer.writerIndex(BitVectorHelper.getValidityBufferSize(valueCount));
+    validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
   }
 
   /**
@@ -318,7 +319,7 @@ public class StructVector extends NonNullableStructVector
   private void splitAndTransferValidityBuffer(int startIndex, int length, StructVector target) {
     int firstByteSource = BitVectorHelper.byteIndex(startIndex);
     int lastByteSource = BitVectorHelper.byteIndex(valueCount - 1);
-    int byteSizeTarget = BitVectorHelper.getValidityBufferSize(length);
+    int byteSizeTarget = getValidityBufferSizeFromCount(length);
     int offset = startIndex % 8;
 
     if (length > 0) {
@@ -464,7 +465,7 @@ public class StructVector extends NonNullableStructVector
     if (valueCount == 0) {
       return 0;
     }
-    return super.getBufferSize() + BitVectorHelper.getValidityBufferSize(valueCount);
+    return super.getBufferSize() + getValidityBufferSizeFromCount(valueCount);
   }
 
   /**
@@ -478,18 +479,18 @@ public class StructVector extends NonNullableStructVector
     if (valueCount == 0) {
       return 0;
     }
-    return super.getBufferSizeFor(valueCount) + BitVectorHelper.getValidityBufferSize(valueCount);
+    return super.getBufferSizeFor(valueCount) + getValidityBufferSizeFromCount(valueCount);
   }
 
   @Override
   public void setInitialCapacity(int numRecords) {
-    validityAllocationSizeInBytes = BitVectorHelper.getValidityBufferSize(numRecords);
+    validityAllocationSizeInBytes = getValidityBufferSizeFromCount(numRecords);
     super.setInitialCapacity(numRecords);
   }
 
   @Override
   public void setInitialCapacity(int numRecords, double density) {
-    validityAllocationSizeInBytes = BitVectorHelper.getValidityBufferSize(numRecords);
+    validityAllocationSizeInBytes = getValidityBufferSizeFromCount(numRecords);
     super.setInitialCapacity(numRecords, density);
   }
 
@@ -547,7 +548,7 @@ public class StructVector extends NonNullableStructVector
         newAllocationSize = validityAllocationSizeInBytes;
       } else {
         newAllocationSize =
-            BitVectorHelper.getValidityBufferSize(BaseValueVector.INITIAL_VALUE_ALLOCATION) * 2L;
+            getValidityBufferSizeFromCount(BaseValueVector.INITIAL_VALUE_ALLOCATION) * 2L;
       }
     }
     newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);

--- a/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -20,6 +20,7 @@ import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
 import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.apache.arrow.vector.BufferLayout.BufferType.DATA;
 import static org.apache.arrow.vector.BufferLayout.BufferType.OFFSET;
 import static org.apache.arrow.vector.BufferLayout.BufferType.SIZE;
@@ -381,7 +382,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
         new BufferReader() {
           @Override
           protected ArrowBuf read(BufferAllocator allocator, int count) throws IOException {
-            final int bufferSize = BitVectorHelper.getValidityBufferSize(count);
+            final int bufferSize = getValidityBufferSizeFromCount(count);
             ArrowBuf buf = allocator.buffer(bufferSize);
 
             // C++ integration test fails without this.

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -943,7 +944,7 @@ public class TestLargeListVector {
       int[] indices = new int[] {0, 2, 4, 6, 10, 14};
 
       for (int valueCount = 1; valueCount <= 5; valueCount++) {
-        int validityBufferSize = BitVectorHelper.getValidityBufferSize(valueCount);
+        int validityBufferSize = getValidityBufferSizeFromCount(valueCount);
         int offsetBufferSize = (valueCount + 1) * LargeListVector.OFFSET_WIDTH;
 
         int expectedSize =

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListViewVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListViewVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -1062,7 +1063,7 @@ public class TestLargeListViewVector {
       int[] indices = new int[] {0, 2, 4, 6, 10, 14};
 
       for (int valueCount = 1; valueCount <= 5; valueCount++) {
-        int validityBufferSize = BitVectorHelper.getValidityBufferSize(valueCount);
+        int validityBufferSize = getValidityBufferSizeFromCount(valueCount);
         int offsetBufferSize = valueCount * BaseLargeRepeatedValueViewVector.OFFSET_WIDTH;
         int sizeBufferSize = valueCount * BaseLargeRepeatedValueViewVector.SIZE_WIDTH;
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1123,7 +1124,7 @@ public class TestListVector {
       int[] indices = new int[] {0, 2, 4, 6, 10, 14};
 
       for (int valueCount = 1; valueCount <= 5; valueCount++) {
-        int validityBufferSize = BitVectorHelper.getValidityBufferSize(valueCount);
+        int validityBufferSize = getValidityBufferSizeFromCount(valueCount);
         int offsetBufferSize = (valueCount + 1) * BaseRepeatedValueVector.OFFSET_WIDTH;
 
         int expectedSize =

--- a/vector/src/test/java/org/apache/arrow/vector/TestListViewVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListViewVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1075,7 +1076,7 @@ public class TestListViewVector {
       int[] indices = new int[] {0, 2, 4, 6, 10, 14};
 
       for (int valueCount = 1; valueCount <= 5; valueCount++) {
-        int validityBufferSize = BitVectorHelper.getValidityBufferSize(valueCount);
+        int validityBufferSize = getValidityBufferSizeFromCount(valueCount);
         int offsetBufferSize = valueCount * BaseRepeatedValueViewVector.OFFSET_WIDTH;
         int sizeBufferSize = valueCount * BaseRepeatedValueViewVector.SIZE_WIDTH;
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.apache.arrow.vector.TestUtils.newVarBinaryVector;
 import static org.apache.arrow.vector.TestUtils.newVarCharVector;
 import static org.apache.arrow.vector.TestUtils.newVector;
@@ -1233,7 +1234,7 @@ public class TestValueVector {
       // the size needed for the validity buffer
       final long validitySize =
           DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY.getRoundedSize(
-              BaseValueVector.getValidityBufferSizeFromCount(2));
+              getValidityBufferSizeFromCount(2));
       assertEquals(allocatedMem + validitySize, allocator.getAllocatedMemory());
       // The validity and offset buffers are sliced from a same buffer.See
       // BaseFixedWidthVector#allocateBytes.
@@ -2464,7 +2465,7 @@ public class TestValueVector {
       assertTrue(intVector.getValueCapacity() >= defaultCapacity);
       expectedSize =
           (defaultCapacity * IntVector.TYPE_WIDTH)
-              + BaseFixedWidthVector.getValidityBufferSizeFromCount(defaultCapacity);
+              + getValidityBufferSizeFromCount(defaultCapacity);
       assertTrue(childAllocator.getAllocatedMemory() - beforeSize <= expectedSize * 1.05);
 
       // verify that the wastage is within bounds for BigIntVector.
@@ -2473,7 +2474,7 @@ public class TestValueVector {
       assertTrue(bigIntVector.getValueCapacity() >= defaultCapacity);
       expectedSize =
           (defaultCapacity * bigIntVector.TYPE_WIDTH)
-              + BaseFixedWidthVector.getValidityBufferSizeFromCount(defaultCapacity);
+              + getValidityBufferSizeFromCount(defaultCapacity);
       assertTrue(childAllocator.getAllocatedMemory() - beforeSize <= expectedSize * 1.05);
 
       // verify that the wastage is within bounds for DecimalVector.
@@ -2482,7 +2483,7 @@ public class TestValueVector {
       assertTrue(decimalVector.getValueCapacity() >= defaultCapacity);
       expectedSize =
           (defaultCapacity * decimalVector.TYPE_WIDTH)
-              + BaseFixedWidthVector.getValidityBufferSizeFromCount(defaultCapacity);
+              + getValidityBufferSizeFromCount(defaultCapacity);
       assertTrue(childAllocator.getAllocatedMemory() - beforeSize <= expectedSize * 1.05);
 
       // verify that the wastage is within bounds for VarCharVector.
@@ -2492,7 +2493,7 @@ public class TestValueVector {
       assertTrue(varCharVector.getValueCapacity() >= defaultCapacity - 1);
       expectedSize =
           (defaultCapacity * VarCharVector.OFFSET_WIDTH)
-              + BaseFixedWidthVector.getValidityBufferSizeFromCount(defaultCapacity)
+              + getValidityBufferSizeFromCount(defaultCapacity)
               + defaultCapacity * 8;
       // wastage should be less than 5%.
       assertTrue(childAllocator.getAllocatedMemory() - beforeSize <= expectedSize * 1.05);
@@ -2501,7 +2502,7 @@ public class TestValueVector {
       beforeSize = childAllocator.getAllocatedMemory();
       bitVector.allocateNew();
       assertTrue(bitVector.getValueCapacity() >= defaultCapacity);
-      expectedSize = BaseFixedWidthVector.getValidityBufferSizeFromCount(defaultCapacity) * 2;
+      expectedSize = getValidityBufferSizeFromCount(defaultCapacity) * 2;
       assertTrue(childAllocator.getAllocatedMemory() - beforeSize <= expectedSize * 1.05);
     }
   }

--- a/vector/src/test/java/org/apache/arrow/vector/TestVariableWidthViewVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestVariableWidthViewVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.apache.arrow.vector.TestUtils.newVector;
 import static org.apache.arrow.vector.TestUtils.newViewVarBinaryVector;
 import static org.apache.arrow.vector.TestUtils.newViewVarCharVector;
@@ -2367,7 +2368,7 @@ public class TestVariableWidthViewVector {
     // the allocation only consists in the size needed for the validity buffer
     final long validitySize =
         DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY.getRoundedSize(
-            BaseValueVector.getValidityBufferSizeFromCount(2));
+            getValidityBufferSizeFromCount(2));
     // we allocate view and data buffers for the target vector
     assertTrue(allocatedMem + validitySize < allocator.getAllocatedMemory());
     // The validity is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.

--- a/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector;
 
 import static java.util.Arrays.asList;
+import static org.apache.arrow.vector.BitVectorHelper.getValidityBufferSizeFromCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -215,7 +216,7 @@ public class TestVectorUnloadLoad {
     int count = 10;
     ArrowBuf[] values = new ArrowBuf[4];
     for (int i = 0; i < 4; i += 2) {
-      ArrowBuf buf1 = allocator.buffer(BitVectorHelper.getValidityBufferSize(count));
+      ArrowBuf buf1 = allocator.buffer(getValidityBufferSizeFromCount(count));
       ArrowBuf buf2 = allocator.buffer(count * 4); // integers
       buf1.setZero(0, buf1.capacity());
       buf2.setZero(0, buf2.capacity());


### PR DESCRIPTION
## What's Changed
Just removing some duplicate functions in anticipation of cleaning out some transferPair duplication across complex vectors.

Closes #774 
