### PR TITLE
GH-731: Avro adapter, output dictionary-encoded fields as enums

### DIFF
--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
@@ -169,10 +169,10 @@ public class ArrowToAvroUtils {
    * may be nullable. Record types must contain at least one child field and cannot contain multiple
    * fields with the same name
    *
-   * <p>String fields that are dictionary-encoded will be represented as an Avro enum, so long as all
-   * the values meet the restrictions on Avro enums (non-null, valid identifiers). Other data types
-   * that are dictionary encoded, or string fields that do not meet the avro requirements, will be output
-   * as their decoded type.
+   * <p>String fields that are dictionary-encoded will be represented as an Avro enum, so long as
+   * all the values meet the restrictions on Avro enums (non-null, valid identifiers). Other data
+   * types that are dictionary encoded, or string fields that do not meet the avro requirements,
+   * will be output as their decoded type.
    *
    * @param arrowFields The arrow fields used to generate the Avro schema
    * @param typeName Name of the top level Avro record type

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
@@ -17,7 +17,10 @@
 package org.apache.arrow.adapter.avro;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.apache.arrow.adapter.avro.producers.AvroBigIntProducer;
 import org.apache.arrow.adapter.avro.producers.AvroBooleanProducer;
 import org.apache.arrow.adapter.avro.producers.AvroBytesProducer;
@@ -96,11 +99,15 @@ import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.util.Text;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -162,17 +169,29 @@ public class ArrowToAvroUtils {
    * may be nullable. Record types must contain at least one child field and cannot contain multiple
    * fields with the same name
    *
+   * <p>String fields that are dictionary-encoded will be represented as an Avro enum, so long as all
+   * the values meet the restrictions on Avro enums (non-null, valid identifiers). Other data types
+   * that are dictionary encoded, or string fields that do not meet the avro requirements, will be output
+   * as their decoded type.
+   *
    * @param arrowFields The arrow fields used to generate the Avro schema
    * @param typeName Name of the top level Avro record type
    * @param namespace Namespace of the top level Avro record type
+   * @param dictionaries A dictionary provider is required if any fields use dictionary encoding
    * @return An Avro record schema for the given list of fields, with the specified name and
    *     namespace
    */
   public static Schema createAvroSchema(
-      List<Field> arrowFields, String typeName, String namespace) {
+      List<Field> arrowFields, String typeName, String namespace, DictionaryProvider dictionaries) {
     SchemaBuilder.RecordBuilder<Schema> assembler =
         SchemaBuilder.record(typeName).namespace(namespace);
-    return buildRecordSchema(assembler, arrowFields, namespace);
+    return buildRecordSchema(assembler, arrowFields, namespace, dictionaries);
+  }
+
+  /** Overload provided for convenience, sets dictionaries = null. */
+  public static Schema createAvroSchema(
+      List<Field> arrowFields, String typeName, String namespace) {
+    return createAvroSchema(arrowFields, typeName, namespace, null);
   }
 
   /** Overload provided for convenience, sets namespace = null. */
@@ -185,61 +204,83 @@ public class ArrowToAvroUtils {
     return createAvroSchema(arrowFields, GENERIC_RECORD_TYPE_NAME);
   }
 
+  /**
+   * Overload provided for convenience, sets name = GENERIC_RECORD_TYPE_NAME and namespace = null.
+   */
+  public static Schema createAvroSchema(List<Field> arrowFields, DictionaryProvider dictionaries) {
+    return createAvroSchema(arrowFields, GENERIC_RECORD_TYPE_NAME, null, dictionaries);
+  }
+
   private static <T> T buildRecordSchema(
-      SchemaBuilder.RecordBuilder<T> builder, List<Field> fields, String namespace) {
+      SchemaBuilder.RecordBuilder<T> builder,
+      List<Field> fields,
+      String namespace,
+      DictionaryProvider dictionaries) {
     if (fields.isEmpty()) {
       throw new IllegalArgumentException("Record field must have at least one child field");
     }
     SchemaBuilder.FieldAssembler<T> assembler = builder.namespace(namespace).fields();
     for (Field field : fields) {
-      assembler = buildFieldSchema(assembler, field, namespace);
+      assembler = buildFieldSchema(assembler, field, namespace, dictionaries);
     }
     return assembler.endRecord();
   }
 
   private static <T> SchemaBuilder.FieldAssembler<T> buildFieldSchema(
-      SchemaBuilder.FieldAssembler<T> assembler, Field field, String namespace) {
+      SchemaBuilder.FieldAssembler<T> assembler,
+      Field field,
+      String namespace,
+      DictionaryProvider dictionaries) {
 
     return assembler
         .name(field.getName())
-        .type(buildTypeSchema(SchemaBuilder.builder(), field, namespace))
+        .type(buildTypeSchema(SchemaBuilder.builder(), field, namespace, dictionaries))
         .noDefault();
   }
 
   private static <T> T buildTypeSchema(
-      SchemaBuilder.TypeBuilder<T> builder, Field field, String namespace) {
+      SchemaBuilder.TypeBuilder<T> builder,
+      Field field,
+      String namespace,
+      DictionaryProvider dictionaries) {
 
     // Nullable unions need special handling, since union types cannot be directly nested
     if (field.getType().getTypeID() == ArrowType.ArrowTypeID.Union) {
       boolean unionNullable = field.getChildren().stream().anyMatch(Field::isNullable);
       if (unionNullable) {
         SchemaBuilder.UnionAccumulator<T> union = builder.unionOf().nullType();
-        return addTypesToUnion(union, field.getChildren(), namespace);
+        return addTypesToUnion(union, field.getChildren(), namespace, dictionaries);
       } else {
         Field headType = field.getChildren().get(0);
         List<Field> tailTypes = field.getChildren().subList(1, field.getChildren().size());
         SchemaBuilder.UnionAccumulator<T> union =
-            buildBaseTypeSchema(builder.unionOf(), headType, namespace);
-        return addTypesToUnion(union, tailTypes, namespace);
+            buildBaseTypeSchema(builder.unionOf(), headType, namespace, dictionaries);
+        return addTypesToUnion(union, tailTypes, namespace, dictionaries);
       }
     } else if (field.isNullable()) {
-      return buildBaseTypeSchema(builder.nullable(), field, namespace);
+      return buildBaseTypeSchema(builder.nullable(), field, namespace, dictionaries);
     } else {
-      return buildBaseTypeSchema(builder, field, namespace);
+      return buildBaseTypeSchema(builder, field, namespace, dictionaries);
     }
   }
 
   private static <T> T buildArraySchema(
-      SchemaBuilder.ArrayBuilder<T> builder, Field listField, String namespace) {
+      SchemaBuilder.ArrayBuilder<T> builder,
+      Field listField,
+      String namespace,
+      DictionaryProvider dictionaries) {
     if (listField.getChildren().size() != 1) {
       throw new IllegalArgumentException("List field must have exactly one child field");
     }
     Field itemField = listField.getChildren().get(0);
-    return buildTypeSchema(builder.items(), itemField, namespace);
+    return buildTypeSchema(builder.items(), itemField, namespace, dictionaries);
   }
 
   private static <T> T buildMapSchema(
-      SchemaBuilder.MapBuilder<T> builder, Field mapField, String namespace) {
+      SchemaBuilder.MapBuilder<T> builder,
+      Field mapField,
+      String namespace,
+      DictionaryProvider dictionaries) {
     if (mapField.getChildren().size() != 1) {
       throw new IllegalArgumentException("Map field must have exactly one child field");
     }
@@ -253,11 +294,14 @@ public class ArrowToAvroUtils {
       throw new IllegalArgumentException(
           "Map keys must be of type string and cannot be nullable for conversion to Avro");
     }
-    return buildTypeSchema(builder.values(), valueField, namespace);
+    return buildTypeSchema(builder.values(), valueField, namespace, dictionaries);
   }
 
   private static <T> T buildBaseTypeSchema(
-      SchemaBuilder.BaseTypeBuilder<T> builder, Field field, String namespace) {
+      SchemaBuilder.BaseTypeBuilder<T> builder,
+      Field field,
+      String namespace,
+      DictionaryProvider dictionaries) {
 
     ArrowType.ArrowTypeID typeID = field.getType().getTypeID();
 
@@ -269,6 +313,33 @@ public class ArrowToAvroUtils {
         return builder.booleanType();
 
       case Int:
+        if (field.getDictionary() != null) {
+          if (dictionaries == null) {
+            throw new IllegalArgumentException(
+                "Field references a dictionary but no dictionaries were provided: "
+                    + field.getName());
+          }
+          Dictionary dictionary = dictionaries.lookup(field.getDictionary().getId());
+          if (dictionary == null) {
+            throw new IllegalArgumentException(
+                "Field references a dictionary that does not exist: "
+                    + field.getName()
+                    + ", dictionary ID = "
+                    + field.getDictionary().getId());
+          }
+          if (dictionaryIsValidEnum(dictionary)) {
+            String[] symbols = dictionarySymbols(dictionary);
+            return builder.enumeration(field.getName()).symbols(symbols);
+          } else {
+            Field decodedField =
+                new Field(
+                    field.getName(),
+                    dictionary.getVector().getField().getFieldType(),
+                    dictionary.getVector().getField().getChildren());
+            return buildBaseTypeSchema(builder, decodedField, namespace, dictionaries);
+          }
+        }
+
         ArrowType.Int intType = (ArrowType.Int) field.getType();
         if (intType.getBitWidth() > 32 || (intType.getBitWidth() == 32 && !intType.getIsSigned())) {
           return builder.longType();
@@ -328,7 +399,7 @@ public class ArrowToAvroUtils {
         String childNamespace =
             namespace == null ? field.getName() : namespace + "." + field.getName();
         return buildRecordSchema(
-            builder.record(field.getName()), field.getChildren(), childNamespace);
+            builder.record(field.getName()), field.getChildren(), childNamespace, dictionaries);
 
       case List:
       case FixedSizeList:
@@ -339,13 +410,13 @@ public class ArrowToAvroUtils {
               new Field("item", itemField.getFieldType(), itemField.getChildren());
           Field safeListField =
               new Field(field.getName(), field.getFieldType(), List.of(safeItemField));
-          return buildArraySchema(builder.array(), safeListField, namespace);
+          return buildArraySchema(builder.array(), safeListField, namespace, dictionaries);
         } else {
-          return buildArraySchema(builder.array(), field, namespace);
+          return buildArraySchema(builder.array(), field, namespace, dictionaries);
         }
 
       case Map:
-        return buildMapSchema(builder.map(), field, namespace);
+        return buildMapSchema(builder.map(), field, namespace, dictionaries);
 
       default:
         throw new IllegalArgumentException(
@@ -354,9 +425,12 @@ public class ArrowToAvroUtils {
   }
 
   private static <T> T addTypesToUnion(
-      SchemaBuilder.UnionAccumulator<T> accumulator, List<Field> unionFields, String namespace) {
+      SchemaBuilder.UnionAccumulator<T> accumulator,
+      List<Field> unionFields,
+      String namespace,
+      DictionaryProvider dictionaries) {
     for (var field : unionFields) {
-      accumulator = buildBaseTypeSchema(accumulator.and(), field, namespace);
+      accumulator = buildBaseTypeSchema(accumulator.and(), field, namespace, dictionaries);
     }
     return accumulator.endUnion();
   }
@@ -373,30 +447,78 @@ public class ArrowToAvroUtils {
     }
   }
 
+  private static boolean dictionaryIsValidEnum(Dictionary dictionary) {
+
+    if (dictionary.getVectorType().getTypeID() != ArrowType.ArrowTypeID.Utf8) {
+      return false;
+    }
+
+    VarCharVector vector = (VarCharVector) dictionary.getVector();
+    Set<String> symbols = new HashSet<>();
+
+    for (int i = 0; i < vector.getValueCount(); i++) {
+      if (vector.isNull(i)) return false;
+      Text text = vector.getObject(i);
+      if (text == null) return false;
+      String symbol = text.toString();
+      if (!ENUM_REGEX.matcher(symbol).matches()) return false;
+      if (symbols.contains(symbol)) return false;
+      symbols.add(symbol);
+    }
+
+    return true;
+  }
+
+  private static String[] dictionarySymbols(Dictionary dictionary) {
+
+    VarCharVector vector = (VarCharVector) dictionary.getVector();
+    String[] symbols = new String[vector.getValueCount()];
+
+    for (int i = 0; i < vector.getValueCount(); i++) {
+      Text text = vector.getObject(i);
+      // This should never happen if dictionaryIsValidEnum() succeeded
+      if (text == null) throw new IllegalArgumentException("Illegal null value in enum");
+      symbols[i] = text.toString();
+    }
+
+    return symbols;
+  }
+
+  private static final Pattern ENUM_REGEX = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
+
   /**
    * Create a composite Avro producer for a set of field vectors (typically the root set of a VSR).
    *
    * @param vectors The vectors that will be used to produce Avro data
    * @return The resulting composite Avro producer
    */
-  public static CompositeAvroProducer createCompositeProducer(List<FieldVector> vectors) {
+  public static CompositeAvroProducer createCompositeProducer(
+      List<FieldVector> vectors, DictionaryProvider dictionaries) {
 
     List<Producer<? extends FieldVector>> producers = new ArrayList<>(vectors.size());
 
     for (FieldVector vector : vectors) {
-      BaseAvroProducer<? extends FieldVector> producer = createProducer(vector);
+      BaseAvroProducer<? extends FieldVector> producer = createProducer(vector, dictionaries);
       producers.add(producer);
     }
 
     return new CompositeAvroProducer(producers);
   }
 
-  private static BaseAvroProducer<?> createProducer(FieldVector vector) {
-    boolean nullable = vector.getField().isNullable();
-    return createProducer(vector, nullable);
+  /** Overload provided for convenience, sets dictionaries = null. */
+  public static CompositeAvroProducer createCompositeProducer(List<FieldVector> vectors) {
+
+    return createCompositeProducer(vectors, null);
   }
 
-  private static BaseAvroProducer<?> createProducer(FieldVector vector, boolean nullable) {
+  private static BaseAvroProducer<?> createProducer(
+      FieldVector vector, DictionaryProvider dictionaries) {
+    boolean nullable = vector.getField().isNullable();
+    return createProducer(vector, nullable, dictionaries);
+  }
+
+  private static BaseAvroProducer<?> createProducer(
+      FieldVector vector, boolean nullable, DictionaryProvider dictionaries) {
 
     Preconditions.checkNotNull(vector, "Arrow vector object can't be null");
 
@@ -405,8 +527,30 @@ public class ArrowToAvroUtils {
     // Avro understands nullable types as a union of type | null
     // Most nullable fields in a VSR will not be unions, so provide a special wrapper
     if (nullable && minorType != Types.MinorType.UNION) {
-      final BaseAvroProducer<?> innerProducer = createProducer(vector, false);
+      final BaseAvroProducer<?> innerProducer = createProducer(vector, false, dictionaries);
       return new AvroNullableProducer<>(innerProducer);
+    }
+
+    if (vector.getField().getDictionary() != null) {
+      if (dictionaries == null) {
+        throw new IllegalArgumentException(
+            "Field references a dictionary but no dictionaries were provided: "
+                + vector.getField().getName());
+      }
+      Dictionary dictionary = dictionaries.lookup(vector.getField().getDictionary().getId());
+      if (dictionary == null) {
+        throw new IllegalArgumentException(
+            "Field references a dictionary that does not exist: "
+                + vector.getField().getName()
+                + ", dictionary ID = "
+                + vector.getField().getDictionary().getId());
+      }
+      // If a field is dictionary-encoded but cannot be represented as an Avro enum,
+      // then decode it before writing
+      if (!dictionaryIsValidEnum(dictionary)) {
+        FieldVector decodedVector = (FieldVector) DictionaryEncoder.decode(vector, dictionary);
+        return createProducer(decodedVector, nullable, dictionaries);
+      }
     }
 
     switch (minorType) {
@@ -486,21 +630,23 @@ public class ArrowToAvroUtils {
         Producer<?>[] childProducers = new Producer<?>[childVectors.size()];
         for (int i = 0; i < childVectors.size(); i++) {
           FieldVector childVector = childVectors.get(i);
-          childProducers[i] = createProducer(childVector, childVector.getField().isNullable());
+          childProducers[i] =
+              createProducer(childVector, childVector.getField().isNullable(), dictionaries);
         }
         return new AvroStructProducer(structVector, childProducers);
 
       case LIST:
         ListVector listVector = (ListVector) vector;
         FieldVector itemVector = listVector.getDataVector();
-        Producer<?> itemProducer = createProducer(itemVector, itemVector.getField().isNullable());
+        Producer<?> itemProducer =
+            createProducer(itemVector, itemVector.getField().isNullable(), dictionaries);
         return new AvroListProducer(listVector, itemProducer);
 
       case FIXED_SIZE_LIST:
         FixedSizeListVector fixedListVector = (FixedSizeListVector) vector;
         FieldVector fixedItemVector = fixedListVector.getDataVector();
         Producer<?> fixedItemProducer =
-            createProducer(fixedItemVector, fixedItemVector.getField().isNullable());
+            createProducer(fixedItemVector, fixedItemVector.getField().isNullable(), dictionaries);
         return new AvroFixedSizeListProducer(fixedListVector, fixedItemProducer);
 
       case MAP:
@@ -514,7 +660,7 @@ public class ArrowToAvroUtils {
         FieldVector valueVector = entryVector.getChildrenFromFields().get(1);
         Producer<?> keyProducer = new AvroStringProducer(keyVector);
         Producer<?> valueProducer =
-            createProducer(valueVector, valueVector.getField().isNullable());
+            createProducer(valueVector, valueVector.getField().isNullable(), dictionaries);
         Producer<?> entryProducer =
             new AvroStructProducer(entryVector, new Producer<?>[] {keyProducer, valueProducer});
         return new AvroMapProducer(mapVector, entryProducer);

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
@@ -457,12 +457,20 @@ public class ArrowToAvroUtils {
     Set<String> symbols = new HashSet<>();
 
     for (int i = 0; i < vector.getValueCount(); i++) {
-      if (vector.isNull(i)) return false;
+      if (vector.isNull(i)) {
+        return false;
+      }
       Text text = vector.getObject(i);
-      if (text == null) return false;
+      if (text == null) {
+        return false;
+      }
       String symbol = text.toString();
-      if (!ENUM_REGEX.matcher(symbol).matches()) return false;
-      if (symbols.contains(symbol)) return false;
+      if (!ENUM_REGEX.matcher(symbol).matches()) {
+        return false;
+      }
+      if (symbols.contains(symbol)) {
+        return false;
+      }
       symbols.add(symbol);
     }
 
@@ -477,7 +485,9 @@ public class ArrowToAvroUtils {
     for (int i = 0; i < vector.getValueCount(); i++) {
       Text text = vector.getObject(i);
       // This should never happen if dictionaryIsValidEnum() succeeded
-      if (text == null) throw new IllegalArgumentException("Illegal null value in enum");
+      if (text == null) {
+        throw new IllegalArgumentException("Illegal null value in enum");
+      }
       symbols[i] = text.toString();
     }
 

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/AvroEnumProducer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/AvroEnumProducer.java
@@ -21,8 +21,8 @@ import org.apache.arrow.vector.BaseIntVector;
 import org.apache.avro.io.Encoder;
 
 /**
- * Producer that produces enum values from a dictionary-encoded {@link BaseIntVector}, writes data to an
- * Avro encoder.
+ * Producer that produces enum values from a dictionary-encoded {@link BaseIntVector}, writes data
+ * to an Avro encoder.
  */
 public class AvroEnumProducer extends BaseAvroProducer<BaseIntVector> {
 

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/DictionaryDecodingProducer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/DictionaryDecodingProducer.java
@@ -18,21 +18,28 @@ package org.apache.arrow.adapter.avro.producers;
 
 import java.io.IOException;
 import org.apache.arrow.vector.BaseIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Encoder;
 
 /**
- * Producer that produces enum values from a dictionary-encoded {@link BaseIntVector}, writes data to an
+ * Producer that produces decoded values from a dictionary-encoded {@link BaseIntVector}, writes data to an
  * Avro encoder.
  */
-public class AvroEnumProducer extends BaseAvroProducer<BaseIntVector> {
+public class DictionaryDecodingProducer<T extends FieldVector>
+    extends BaseAvroProducer<BaseIntVector> {
 
-  /** Instantiate an AvroEnumProducer. */
-  public AvroEnumProducer(BaseIntVector vector) {
-    super(vector);
+  private final Producer<T> dictProducer;
+
+  /** Instantiate a DictionaryDecodingProducer. */
+  public DictionaryDecodingProducer(BaseIntVector indexVector, Producer<T> dictProducer) {
+    super(indexVector);
+    this.dictProducer = dictProducer;
   }
 
   @Override
   public void produce(Encoder encoder) throws IOException {
-    encoder.writeEnum((int) vector.getValueAsLong(currentIndex++));
+    int dicIndex = (int) vector.getValueAsLong(currentIndex++);
+    dictProducer.setPosition(dicIndex);
+    dictProducer.produce(encoder);
   }
 }

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/DictionaryDecodingProducer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/DictionaryDecodingProducer.java
@@ -22,8 +22,10 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Encoder;
 
 /**
- * Producer that produces decoded values from a dictionary-encoded {@link BaseIntVector}, writes data to an
- * Avro encoder.
+ * Producer that produces decoded values from a dictionary-encoded {@link BaseIntVector}, writes
+ * data to an Avro encoder.
+ *
+ * @param <T> Type of the underlying dictionary vector
  */
 public class DictionaryDecodingProducer<T extends FieldVector>
     extends BaseAvroProducer<BaseIntVector> {

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/DictionaryDecodingProducer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/producers/DictionaryDecodingProducer.java
@@ -22,8 +22,8 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Encoder;
 
 /**
- * Producer that produces decoded values from a dictionary-encoded {@link BaseIntVector}, writes
- * data to an Avro encoder.
+ * Producer that decodes values from a dictionary-encoded {@link FieldVector}, writes the resulting
+ * values to an Avro encoder.
  *
  * @param <T> Type of the underlying dictionary vector
  */

--- a/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroDataTest.java
+++ b/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroDataTest.java
@@ -76,10 +76,14 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.writer.BaseWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.JsonStringArrayList;
@@ -2813,6 +2817,186 @@ public class ArrowToAvroDataTest {
           } else {
             assertNull(record.get("nullableStruct"));
           }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testWriteDictEnumEncoded() throws Exception {
+
+    BufferAllocator allocator = new RootAllocator();
+
+    // Create a dictionary
+    FieldType dictionaryField = new FieldType(false, new ArrowType.Utf8(), null);
+    VarCharVector dictionaryVector =
+        new VarCharVector(new Field("dictionary", dictionaryField, null), allocator);
+
+    dictionaryVector.allocateNew(3);
+    dictionaryVector.set(0, "apple".getBytes());
+    dictionaryVector.set(1, "banana".getBytes());
+    dictionaryVector.set(2, "cherry".getBytes());
+    dictionaryVector.setValueCount(3);
+
+    Dictionary dictionary =
+        new Dictionary(dictionaryVector, new DictionaryEncoding(1L, false, null));
+    DictionaryProvider dictionaries = new DictionaryProvider.MapDictionaryProvider(dictionary);
+
+    // Field definition
+    FieldType stringField = new FieldType(false, new ArrowType.Utf8(), null);
+    VarCharVector stringVector =
+        new VarCharVector(new Field("enumField", stringField, null), allocator);
+    stringVector.allocateNew(10);
+    stringVector.setSafe(0, "apple".getBytes());
+    stringVector.setSafe(1, "banana".getBytes());
+    stringVector.setSafe(2, "cherry".getBytes());
+    stringVector.setSafe(3, "cherry".getBytes());
+    stringVector.setSafe(4, "apple".getBytes());
+    stringVector.setSafe(5, "banana".getBytes());
+    stringVector.setSafe(6, "apple".getBytes());
+    stringVector.setSafe(7, "cherry".getBytes());
+    stringVector.setSafe(8, "banana".getBytes());
+    stringVector.setSafe(9, "apple".getBytes());
+    stringVector.setValueCount(10);
+
+    IntVector encodedVector = (IntVector) DictionaryEncoder.encode(stringVector, dictionary);
+
+    // Set up VSR
+    List<FieldVector> vectors = Arrays.asList(encodedVector);
+    int rowCount = 10;
+
+    try (VectorSchemaRoot root = new VectorSchemaRoot(vectors)) {
+
+      File dataFile = new File(TMP, "testWriteEnumEncoded.avro");
+
+      // Write an AVRO block using the producer classes
+      try (FileOutputStream fos = new FileOutputStream(dataFile)) {
+        BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(fos, null);
+        CompositeAvroProducer producer =
+            ArrowToAvroUtils.createCompositeProducer(vectors, dictionaries);
+        for (int row = 0; row < rowCount; row++) {
+          producer.produce(encoder);
+        }
+        encoder.flush();
+      }
+
+      // Set up reading the AVRO block as a GenericRecord
+      Schema schema = ArrowToAvroUtils.createAvroSchema(root.getSchema().getFields(), dictionaries);
+      GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>(schema);
+
+      try (InputStream inputStream = new FileInputStream(dataFile)) {
+
+        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+        GenericRecord record = null;
+
+        // Read and check values
+        for (int row = 0; row < rowCount; row++) {
+          record = datumReader.read(record, decoder);
+          // Values read from Avro should be the decoded enum values
+          assertEquals(stringVector.getObject(row).toString(), record.get("enumField").toString());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testWriteEnumDecoded() throws Exception {
+
+    // Dict encoded fields that are not valid Avro enums should be decoded on write
+
+    BufferAllocator allocator = new RootAllocator();
+
+    // Create a dictionary
+    FieldType dictionaryField = new FieldType(false, new ArrowType.Utf8(), null);
+    VarCharVector dictionaryVector =
+        new VarCharVector(new Field("dictionary", dictionaryField, null), allocator);
+
+    dictionaryVector.allocateNew(3);
+    dictionaryVector.set(0, "passion fruit".getBytes()); // spaced not allowed
+    dictionaryVector.set(1, "banana".getBytes());
+    dictionaryVector.set(2, "cherry".getBytes());
+    dictionaryVector.setValueCount(3);
+
+    Dictionary dictionary =
+        new Dictionary(dictionaryVector, new DictionaryEncoding(1L, false, null));
+
+    FieldType dictionaryField2 = new FieldType(false, new ArrowType.Int(64, true), null);
+    BigIntVector dictionaryVector2 =
+        new BigIntVector(new Field("dictionary2", dictionaryField2, null), allocator);
+
+    dictionaryVector2.allocateNew(3);
+    dictionaryVector2.set(0, 0L);
+    dictionaryVector2.set(1, 1L);
+    dictionaryVector2.set(2, 2L);
+    dictionaryVector2.setValueCount(3);
+
+    Dictionary dictionary2 =
+        new Dictionary(dictionaryVector2, new DictionaryEncoding(2L, false, null));
+
+    DictionaryProvider dictionaries =
+        new DictionaryProvider.MapDictionaryProvider(dictionary, dictionary2);
+
+    // Field definition
+    FieldType stringField = new FieldType(false, new ArrowType.Utf8(), null);
+    VarCharVector stringVector =
+        new VarCharVector(new Field("enumField", stringField, null), allocator);
+    stringVector.allocateNew(10);
+    stringVector.setSafe(0, "passion fruit".getBytes());
+    stringVector.setSafe(1, "banana".getBytes());
+    stringVector.setSafe(2, "cherry".getBytes());
+    stringVector.setSafe(3, "cherry".getBytes());
+    stringVector.setSafe(4, "passion fruit".getBytes());
+    stringVector.setSafe(5, "banana".getBytes());
+    stringVector.setSafe(6, "passion fruit".getBytes());
+    stringVector.setSafe(7, "cherry".getBytes());
+    stringVector.setSafe(8, "banana".getBytes());
+    stringVector.setSafe(9, "passion fruit".getBytes());
+    stringVector.setValueCount(10);
+
+    FieldType longField = new FieldType(false, new ArrowType.Int(64, true), null);
+    BigIntVector longVector = new BigIntVector(new Field("enumField2", longField, null), allocator);
+    longVector.allocateNew(10);
+    for (int i = 0; i < 10; i++) {
+      longVector.setSafe(i, (long) i % 3);
+    }
+    longVector.setValueCount(10);
+
+    IntVector encodedVector = (IntVector) DictionaryEncoder.encode(stringVector, dictionary);
+    IntVector encodedVector2 = (IntVector) DictionaryEncoder.encode(longVector, dictionary2);
+
+    // Set up VSR
+    List<FieldVector> vectors = Arrays.asList(encodedVector, encodedVector2);
+    int rowCount = 10;
+
+    try (VectorSchemaRoot root = new VectorSchemaRoot(vectors)) {
+
+      File dataFile = new File(TMP, "testWriteEnumDecodedavro");
+
+      // Write an AVRO block using the producer classes
+      try (FileOutputStream fos = new FileOutputStream(dataFile)) {
+        BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(fos, null);
+        CompositeAvroProducer producer =
+            ArrowToAvroUtils.createCompositeProducer(vectors, dictionaries);
+        for (int row = 0; row < rowCount; row++) {
+          producer.produce(encoder);
+        }
+        encoder.flush();
+      }
+
+      // Set up reading the AVRO block as a GenericRecord
+      Schema schema = ArrowToAvroUtils.createAvroSchema(root.getSchema().getFields(), dictionaries);
+      GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>(schema);
+
+      try (InputStream inputStream = new FileInputStream(dataFile)) {
+
+        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+        GenericRecord record = null;
+
+        // Read and check values
+        for (int row = 0; row < rowCount; row++) {
+          record = datumReader.read(record, decoder);
+          assertEquals(stringVector.getObject(row).toString(), record.get("enumField").toString());
+          assertEquals(longVector.getObject(row), record.get("enumField2"));
         }
       }
     }

--- a/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroDataTest.java
+++ b/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroDataTest.java
@@ -2872,7 +2872,8 @@ public class ArrowToAvroDataTest {
       // Write an AVRO block using the producer classes
       try (FileOutputStream fos = new FileOutputStream(dataFile)) {
         BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(fos, null);
-        CompositeAvroProducer producer = ArrowToAvroUtils.createCompositeProducer(vectors, dictionaries);
+        CompositeAvroProducer producer =
+            ArrowToAvroUtils.createCompositeProducer(vectors, dictionaries);
         for (int row = 0; row < rowCount; row++) {
           producer.produce(encoder);
         }

--- a/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroSchemaTest.java
+++ b/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroSchemaTest.java
@@ -17,11 +17,13 @@
 package org.apache.arrow.adapter.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
@@ -1436,5 +1438,85 @@ public class ArrowToAvroSchemaTest {
     assertEquals("apple", enumField.schema().getEnumSymbols().get(0));
     assertEquals("banana", enumField.schema().getEnumSymbols().get(1));
     assertEquals("cherry", enumField.schema().getEnumSymbols().get(2));
+  }
+
+  @Test
+  public void testWriteDictEnumInvalid() {
+
+    BufferAllocator allocator = new RootAllocator();
+
+    // Create a dictionary
+    FieldType dictionaryField = new FieldType(false, new ArrowType.Utf8(), null);
+    VarCharVector dictionaryVector =
+        new VarCharVector(new Field("dictionary", dictionaryField, null), allocator);
+
+    dictionaryVector.allocateNew(3);
+    dictionaryVector.set(0, "passion fruit".getBytes());
+    dictionaryVector.set(1, "banana".getBytes());
+    dictionaryVector.set(2, "cherry".getBytes());
+    dictionaryVector.setValueCount(3);
+
+    Dictionary dictionary =
+        new Dictionary(
+            dictionaryVector, new DictionaryEncoding(0L, false, new ArrowType.Int(8, true)));
+    DictionaryProvider dictionaries = new DictionaryProvider.MapDictionaryProvider(dictionary);
+
+    List<Field> fields =
+        Arrays.asList(
+            new Field(
+                "enumField",
+                new FieldType(false, new ArrowType.Int(8, true), dictionary.getEncoding(), null),
+                null));
+
+    // Dictionary field contains values that are not valid enums
+    // Should be decoded and output as a string field
+
+    Schema schema = ArrowToAvroUtils.createAvroSchema(fields, "TestRecord", null, dictionaries);
+
+    assertEquals(Schema.Type.RECORD, schema.getType());
+    assertEquals(1, schema.getFields().size());
+
+    Schema.Field enumField = schema.getField("enumField");
+    assertEquals(Schema.Type.STRING, enumField.schema().getType());
+  }
+
+  @Test
+  public void testWriteDictEnumInvalid2() {
+
+    BufferAllocator allocator = new RootAllocator();
+
+    // Create a dictionary
+    FieldType dictionaryField = new FieldType(false, new ArrowType.Int(64, true), null);
+    BigIntVector dictionaryVector =
+        new BigIntVector(new Field("dictionary", dictionaryField, null), allocator);
+
+    dictionaryVector.allocateNew(3);
+    dictionaryVector.set(0, 123L);
+    dictionaryVector.set(1, 456L);
+    dictionaryVector.set(2, 789L);
+    dictionaryVector.setValueCount(3);
+
+    Dictionary dictionary =
+        new Dictionary(
+            dictionaryVector, new DictionaryEncoding(0L, false, new ArrowType.Int(8, true)));
+    DictionaryProvider dictionaries = new DictionaryProvider.MapDictionaryProvider(dictionary);
+
+    List<Field> fields =
+        Arrays.asList(
+            new Field(
+                "enumField",
+                new FieldType(false, new ArrowType.Int(8, true), dictionary.getEncoding(), null),
+                null));
+
+    // Dictionary field encodes LONG values rather than STRING
+    // Should be doecded and output as a LONG field
+
+    Schema schema = ArrowToAvroUtils.createAvroSchema(fields, "TestRecord", null, dictionaries);
+
+    assertEquals(Schema.Type.RECORD, schema.getType());
+    assertEquals(1, schema.getFields().size());
+
+    Schema.Field enumField = schema.getField("enumField");
+    assertEquals(Schema.Type.LONG, enumField.schema().getType());
   }
 }

--- a/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroSchemaTest.java
+++ b/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/ArrowToAvroSchemaTest.java
@@ -17,7 +17,6 @@
 package org.apache.arrow.adapter.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
## What's Changed

Updated ArrowToAvro to output dictionary-encoded string vectors as Avro enums, where possible. Apologies for the delay - busy as usual!

To output dict encoded vectors as enums, a dictionary provider must be supplied to the top level methods with all the required dictionaries. All dictionary values must be present when the schema is written, i.e. before the data blocks are produced. If data is being written as a schema followed by multiple blocks, values added to a dictionary in between blocks will not be included in the schema resulting in an invalid Avro file (in general supply an invalid dictionary mapping will result in invalid output).

Dictionary encoded fields are checked to ensure they are valid Avro enums. If the dictionary encoded field is not a string field, or the string values are not valid Avro enums, the field is decoded and output as literal values. This is done by calling DictionaryEncoder.decode(vector, dictionary), which will consume memory for the vector. An alternative approach would be to decode values one-by-one, however this would require a significant change to the producer pattern since the current producers expect concrete vectors of the output type. Another option would be to throw an error if there are dictionary-encoded vectors that are not string types, i.e. push the responsibility onto client code. I'm not sure which approach is best - happy to take any guidance and I will update the code accordingly.

To read enums back the current approach for decoding is unchanged (the AvroToArrow config has to be set up with a MapDictionaryProvider which is populated when data is read). The last part of the Avro work is to add the capability for reading / writing whole files block-by-block, so there is an opportunity to do something with the top level APIs there, for now the current API works and I've used it in the round trip tests.

Please let me know any feedback, happy to update as needed!

Closes #731.
