### PR TITLE
GH-155: Delegate opening mTLS cert files to `build()`

### DIFF
--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -572,17 +572,17 @@ public class FlightServer implements AutoCloseable {
     }
 
     private void prepareTlsSettings() throws IOException {
-      if (this.keyFile != null) {
-        closeKey();
-        this.key = new FileInputStream(this.keyFile);
+      if (this.mTlsCACertFile != null) {
+        closeMTlsCACert();
+        this.mTlsCACert = new FileInputStream(this.mTlsCACertFile);
       }
       if (this.certChainFile != null) {
         closeCertChain();
         this.certChain = new FileInputStream(this.certChainFile);
       }
-      if (this.mTlsCACertFile != null) {
-        closeMTlsCACert();
-        this.mTlsCACert = new FileInputStream(this.mTlsCACertFile);
+      if (this.keyFile != null) {
+        closeKey();
+        this.key = new FileInputStream(this.keyFile);
       }
     }
   }


### PR DESCRIPTION
## What's Changed
Make `FlightServer.Builder` store `File` and delegate opening the file to the actual `build()` method.

Closes #155.
