### PR TITLE
GH-788: Bump Windows GitHub hosted runner to windows-2022 on release workflow

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -354,7 +354,7 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           REM For ORC
           set TZDIR=/c/msys64/usr/share/zoneinfo
           bash -c "ci/scripts/jni_windows_build.sh . arrow build jni"


### PR DESCRIPTION
## What's Changed

Update the Windows runner version.

GitHub is deprecating Windows hosted runners for 2019, see:
- https://github.com/actions/runner-images/issues/12045

We did update on the main Apache Arrow repo already, see:
- https://github.com/apache/arrow/pull/46694

Closes #788 .
