### PR TITLE
GH-804: Prepend JDBC FlightSQL version to user agent

### DIFF
--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
@@ -60,7 +60,6 @@ public class NettyClientBuilder {
   protected String overrideHostname = null;
   protected List<FlightClientMiddleware.Factory> middleware = new ArrayList<>();
   protected boolean verifyServer = true;
-  protected String userAgent;
 
   public NettyClientBuilder() {}
 
@@ -128,11 +127,6 @@ public class NettyClientBuilder {
 
   public NettyClientBuilder verifyServer(boolean verifyServer) {
     this.verifyServer = verifyServer;
-    return this;
-  }
-
-  public NettyClientBuilder userAgent(String userAgent) {
-    this.userAgent = userAgent;
     return this;
   }
 
@@ -232,8 +226,7 @@ public class NettyClientBuilder {
     builder
         .maxTraceEvents(MAX_CHANNEL_TRACE_EVENTS)
         .maxInboundMessageSize(maxInboundMessageSize)
-        .maxInboundMetadataSize(maxInboundMessageSize)
-        .userAgent(userAgent);
+        .maxInboundMetadataSize(maxInboundMessageSize);
     return builder;
   }
 }

--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
@@ -60,6 +60,7 @@ public class NettyClientBuilder {
   protected String overrideHostname = null;
   protected List<FlightClientMiddleware.Factory> middleware = new ArrayList<>();
   protected boolean verifyServer = true;
+  protected String userAgent;
 
   public NettyClientBuilder() {}
 
@@ -127,6 +128,11 @@ public class NettyClientBuilder {
 
   public NettyClientBuilder verifyServer(boolean verifyServer) {
     this.verifyServer = verifyServer;
+    return this;
+  }
+
+  public NettyClientBuilder userAgent(String userAgent) {
+    this.userAgent = userAgent;
     return this;
   }
 
@@ -226,7 +232,8 @@ public class NettyClientBuilder {
     builder
         .maxTraceEvents(MAX_CHANNEL_TRACE_EVENTS)
         .maxInboundMessageSize(maxInboundMessageSize)
-        .maxInboundMetadataSize(maxInboundMessageSize);
+        .maxInboundMetadataSize(maxInboundMessageSize)
+        .userAgent(userAgent);
     return builder;
   }
 }

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
@@ -32,6 +32,7 @@ import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.util.Preconditions;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaFactory;
+import org.apache.calcite.avatica.DriverVersion;
 
 /** Connection to the Arrow Flight server. */
 public final class ArrowFlightConnection extends AvaticaConnection {
@@ -86,13 +87,16 @@ public final class ArrowFlightConnection extends AvaticaConnection {
       throws SQLException {
     url = replaceSemiColons(url);
     final ArrowFlightConnectionConfigImpl config = new ArrowFlightConnectionConfigImpl(properties);
-    final ArrowFlightSqlClientHandler clientHandler = createNewClientHandler(config, allocator);
+    final ArrowFlightSqlClientHandler clientHandler =
+        createNewClientHandler(config, allocator, driver.getDriverVersion());
     return new ArrowFlightConnection(
         driver, factory, url, properties, config, allocator, clientHandler);
   }
 
   private static ArrowFlightSqlClientHandler createNewClientHandler(
-      final ArrowFlightConnectionConfigImpl config, final BufferAllocator allocator)
+      final ArrowFlightConnectionConfigImpl config,
+      final BufferAllocator allocator,
+      final DriverVersion driverVersion)
       throws SQLException {
     try {
       return new ArrowFlightSqlClientHandler.Builder()
@@ -116,6 +120,7 @@ public final class ArrowFlightConnection extends AvaticaConnection {
           .withCatalog(config.getCatalog())
           .withClientCache(config.useClientCache() ? new FlightClientCache() : null)
           .withConnectTimeout(config.getConnectTimeout())
+          .withDriverVersion(driverVersion)
           .build();
     } catch (final SQLException e) {
       try {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -66,6 +66,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.calcite.avatica.DriverVersion;
 import org.apache.calcite.avatica.Meta.StatementType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -548,6 +549,9 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
 
   /** Builder for {@link ArrowFlightSqlClientHandler}. */
   public static final class Builder {
+    @VisibleForTesting static final String USER_AGENT_TEMPLATE = "JDBC Flight SQL Driver %s";
+    static final String DEFAULT_VERSION = "(unknown or development build)";
+
     private final Set<FlightClientMiddleware.Factory> middlewareFactories = new HashSet<>();
     private final Set<CallOption> options = new HashSet<>();
     private String host;
@@ -597,6 +601,8 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
     @VisibleForTesting
     ClientCookieMiddleware.Factory cookieFactory = new ClientCookieMiddleware.Factory();
 
+    DriverVersion driverVersion;
+
     public Builder() {}
 
     /**
@@ -631,6 +637,8 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
       if (original.retainAuth) {
         this.authFactory = original.authFactory;
       }
+
+      this.driverVersion = original.driverVersion;
     }
 
     /**
@@ -879,6 +887,17 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Sets the driver version for this handler.
+     *
+     * @param driverVersion the driver version to set
+     * @return this builder instance
+     */
+    public Builder withDriverVersion(DriverVersion driverVersion) {
+      this.driverVersion = driverVersion;
+      return this;
+    }
+
     public String getCacheKey() {
       return getLocation().toString();
     }
@@ -913,6 +932,12 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
         }
         final NettyClientBuilder clientBuilder = new NettyClientBuilder();
         clientBuilder.allocator(allocator);
+
+        String userAgent = String.format(USER_AGENT_TEMPLATE, DEFAULT_VERSION);
+        if (driverVersion != null && driverVersion.versionString != null) {
+          userAgent = String.format(USER_AGENT_TEMPLATE, driverVersion.versionString);
+        }
+        clientBuilder.userAgent(userAgent);
 
         buildTimeMiddlewareFactories.add(new ClientCookieMiddleware.Factory());
         buildTimeMiddlewareFactories.forEach(clientBuilder::intercept);

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -937,7 +937,6 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
         if (driverVersion != null && driverVersion.versionString != null) {
           userAgent = String.format(USER_AGENT_TEMPLATE, driverVersion.versionString);
         }
-        clientBuilder.userAgent(userAgent);
 
         buildTimeMiddlewareFactories.add(new ClientCookieMiddleware.Factory());
         buildTimeMiddlewareFactories.forEach(clientBuilder::intercept);
@@ -973,6 +972,9 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
         }
 
         NettyChannelBuilder channelBuilder = clientBuilder.build();
+
+        channelBuilder.userAgent(userAgent);
+
         if (connectTimeout != null) {
           channelBuilder.withOption(
               ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout.toMillis());

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -549,7 +549,7 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
 
   /** Builder for {@link ArrowFlightSqlClientHandler}. */
   public static final class Builder {
-    @VisibleForTesting static final String USER_AGENT_TEMPLATE = "JDBC Flight SQL Driver %s";
+    static final String USER_AGENT_TEMPLATE = "JDBC Flight SQL Driver %s";
     static final String DEFAULT_VERSION = "(unknown or development build)";
 
     private final Set<FlightClientMiddleware.Factory> middlewareFactories = new HashSet<>();

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionCookieTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionCookieTest.java
@@ -39,11 +39,11 @@ public class ArrowFlightJdbcConnectionCookieTest {
         Statement statement = connection.createStatement()) {
 
       // Expect client didn't receive cookies before any operation
-      assertNull(FLIGHT_SERVER_TEST_EXTENSION.getMiddlewareCookieFactory().getCookie());
+      assertNull(FLIGHT_SERVER_TEST_EXTENSION.getInterceptorFactory().getCookie());
 
       // Run another action for check if the cookies was sent by the server.
       statement.execute(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD);
-      assertEquals("k=v", FLIGHT_SERVER_TEST_EXTENSION.getMiddlewareCookieFactory().getCookie());
+      assertEquals("k=v", FLIGHT_SERVER_TEST_EXTENSION.getInterceptorFactory().getCookie());
     }
   }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
@@ -149,6 +149,7 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
     assertEquals(Optional.empty(), builder.catalog);
     assertNull(builder.flightClientCache);
     assertNull(builder.connectTimeout);
+    assertNull(builder.driverVersion);
   }
 
   @Test


### PR DESCRIPTION
## What's Changed

* Driver version is passed on to NettyBuilderClient to append it to the user-agent header
* NettyBuilderClient now prepends `JDBC Flight SQL Client <version>` to the header (e.g. `JDBC Flight SQL Client 19.0.0-SNAPSHOT grpc-java-netty/1.73.0`)

Closes #804.
