### PR TITLE
JDBC Flight SQL: Suppress benign CloseSession errors in handler.close() when catalog is set

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -262,12 +262,79 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
   @Override
   public void close() throws SQLException {
     if (catalog.isPresent()) {
-      sqlClient.closeSession(new CloseSessionRequest(), getOptions());
+      try {
+        sqlClient.closeSession(new CloseSessionRequest(), getOptions());
+      } catch (FlightRuntimeException fre) {
+        handleBenignCloseException(fre, "Failed to close Flight SQL session.", "closing Flight SQL session");
+      }
     }
     try {
       AutoCloseables.close(sqlClient);
+    } catch (FlightRuntimeException fre) {
+      handleBenignCloseException(fre, "Failed to clean up client resources.", "closing Flight SQL client");
     } catch (final Exception e) {
       throw new SQLException("Failed to clean up client resources.", e);
+    }
+  }
+
+  /**
+   * Handles FlightRuntimeException during close operations, suppressing benign gRPC shutdown errors
+   * while re-throwing genuine failures.
+   *
+   * @param fre the FlightRuntimeException to handle
+   * @param sqlErrorMessage the SQLException message to use for genuine failures
+   * @param operationDescription description of the operation for logging
+   * @throws SQLException if the exception represents a genuine failure
+   */
+  private void handleBenignCloseException(FlightRuntimeException fre, String sqlErrorMessage, String operationDescription) throws SQLException {
+    if (isBenignCloseException(fre)) {
+      logSuppressedCloseException(fre, operationDescription);
+    } else {
+      throw new SQLException(sqlErrorMessage, fre);
+    }
+  }
+
+  /**
+   * Handles FlightRuntimeException during close operations, suppressing benign gRPC shutdown errors
+   * while re-throwing genuine failures as FlightRuntimeException.
+   *
+   * @param fre the FlightRuntimeException to handle
+   * @param operationDescription description of the operation for logging
+   * @throws FlightRuntimeException if the exception represents a genuine failure
+   */
+  private void handleBenignCloseException(FlightRuntimeException fre, String operationDescription) throws FlightRuntimeException {
+    if (isBenignCloseException(fre)) {
+      logSuppressedCloseException(fre, operationDescription);
+    } else {
+      throw fre;
+    }
+  }
+
+  /**
+   * Determines if a FlightRuntimeException represents a benign close operation error
+   * that should be suppressed.
+   *
+   * @param fre the FlightRuntimeException to check
+   * @return true if the exception should be suppressed, false otherwise
+   */
+  private boolean isBenignCloseException(FlightRuntimeException fre) {
+    return fre.status().code().equals(FlightStatusCode.UNAVAILABLE)
+        || (fre.status().code().equals(FlightStatusCode.INTERNAL)
+            && fre.getMessage().contains("Connection closed after GOAWAY"));
+  }
+
+  /**
+   * Logs a suppressed close exception with appropriate level based on debug settings.
+   *
+   * @param fre the FlightRuntimeException being suppressed
+   * @param operationDescription description of the operation for logging
+   */
+  private void logSuppressedCloseException(FlightRuntimeException fre, String operationDescription) {
+    // ARROW-17785: suppress exceptions caused by flaky gRPC layer during shutdown
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Suppressed error {}", operationDescription, fre);
+    } else {
+      LOGGER.info("Suppressed benign error {}: {}", operationDescription, fre.getMessage());
     }
   }
 
@@ -386,14 +453,7 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
         try {
           preparedStatement.close(getOptions());
         } catch (FlightRuntimeException fre) {
-          // ARROW-17785: suppress exceptions caused by flaky gRPC layer
-          if (fre.status().code().equals(FlightStatusCode.UNAVAILABLE)
-              || (fre.status().code().equals(FlightStatusCode.INTERNAL)
-                  && fre.getMessage().contains("Connection closed after GOAWAY"))) {
-            LOGGER.warn("Supressed error closing PreparedStatement", fre);
-            return;
-          }
-          throw fre;
+          handleBenignCloseException(fre, "closing PreparedStatement");
         }
       }
     };


### PR DESCRIPTION
**Summary**
This PR fixes a shutdown-noise issue in the Java Flight SQL JDBC driver when a catalog is set. In that case, ArrowFlightSqlClientHandler.close() performs a CloseSession RPC that can fail if the gRPC channel is already shutting down. Pooling layers (e.g., Apache Commons DBCP used by JMeter) treat that exception as a hard error even though the session is closing. The fix mirrors PreparedStatement.close() (ARROW-17785) by suppressing only transient shutdown errors and surfacing real failures.

**Problem Statement**
• Affected component: flight/flight-sql-jdbc-core – ArrowFlightSqlClientHandler.close()
• Trigger condition: JDBC connection created with a catalog (session option). On close(), the driver calls FlightSqlClient.closeSession().
• Failure mode: During pool/connection teardown, the gRPC channel may be closing already, causing FlightRuntimeException with:

**Why fix in ArrowFlightSqlClientHandler.close()**
• ArrowFlightConnection.close() delegates to clientHandler.close(), and some paths also close the handler via AutoCloseables. Fixing at the handler ensures both code paths are safe.
• This mirrors the precedent already in PreparedStatement.close() (ARROW-17785) where transient gRPC shutdown errors are suppressed.