### PR TITLE
GH-858: Fix error handling in CompositeJdbcConsumer

### DIFF
--- a/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
+++ b/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
@@ -47,7 +47,7 @@ public class CompositeJdbcConsumer implements JdbcConsumer {
               new JdbcFieldInfo(rs.getMetaData(), consumer.columnIndexInResultSet);
 
           throw new JdbcConsumerException(
-              "Exception while consuming JDBC value", e, fieldInfo, consumer.vector.getMinorType());
+              "Exception while consuming JDBC value", e, fieldInfo, consumer.vector.getField());
         } else {
           throw e;
         }

--- a/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
+++ b/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
@@ -24,7 +24,6 @@ import org.apache.arrow.adapter.jdbc.consumer.exceptions.JdbcConsumerException;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /** Composite consumer which hold all consumers. It manages the consume and cleanup process. */
 public class CompositeJdbcConsumer implements JdbcConsumer {
@@ -46,9 +45,9 @@ public class CompositeJdbcConsumer implements JdbcConsumer {
           BaseConsumer consumer = (BaseConsumer) consumers[i];
           JdbcFieldInfo fieldInfo =
               new JdbcFieldInfo(rs.getMetaData(), consumer.columnIndexInResultSet);
-          ArrowType arrowType = consumer.vector.getMinorType().getType();
+
           throw new JdbcConsumerException(
-              "Exception while consuming JDBC value", e, fieldInfo, arrowType);
+              "Exception while consuming JDBC value", e, fieldInfo, consumer.vector.getMinorType());
         } else {
           throw e;
         }

--- a/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/exceptions/JdbcConsumerException.java
+++ b/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/exceptions/JdbcConsumerException.java
@@ -17,7 +17,7 @@
 package org.apache.arrow.adapter.jdbc.consumer.exceptions;
 
 import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
-import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.Types;
 
 /**
  * Exception while consuming JDBC data. This exception stores the JdbcFieldInfo for the column and
@@ -25,7 +25,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
  */
 public class JdbcConsumerException extends RuntimeException {
   final JdbcFieldInfo fieldInfo;
-  final ArrowType arrowType;
+  final Types.MinorType minorType;
 
   /**
    * Construct JdbcConsumerException with all fields.
@@ -33,17 +33,17 @@ public class JdbcConsumerException extends RuntimeException {
    * @param message error message
    * @param cause original exception
    * @param fieldInfo JdbcFieldInfo for the column
-   * @param arrowType ArrowType for the corresponding vector
+   * @param minorType ArrowType for the corresponding vector
    */
   public JdbcConsumerException(
-      String message, Throwable cause, JdbcFieldInfo fieldInfo, ArrowType arrowType) {
+      String message, Throwable cause, JdbcFieldInfo fieldInfo, Types.MinorType minorType) {
     super(message, cause);
     this.fieldInfo = fieldInfo;
-    this.arrowType = arrowType;
+    this.minorType = minorType;
   }
 
-  public ArrowType getArrowType() {
-    return this.arrowType;
+  public Types.MinorType getMinorType() {
+    return this.minorType;
   }
 
   public JdbcFieldInfo getFieldInfo() {

--- a/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/exceptions/JdbcConsumerException.java
+++ b/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/exceptions/JdbcConsumerException.java
@@ -17,7 +17,7 @@
 package org.apache.arrow.adapter.jdbc.consumer.exceptions;
 
 import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
 
 /**
  * Exception while consuming JDBC data. This exception stores the JdbcFieldInfo for the column and
@@ -25,7 +25,7 @@ import org.apache.arrow.vector.types.Types;
  */
 public class JdbcConsumerException extends RuntimeException {
   final JdbcFieldInfo fieldInfo;
-  final Types.MinorType minorType;
+  final Field field;
 
   /**
    * Construct JdbcConsumerException with all fields.
@@ -33,17 +33,17 @@ public class JdbcConsumerException extends RuntimeException {
    * @param message error message
    * @param cause original exception
    * @param fieldInfo JdbcFieldInfo for the column
-   * @param minorType ArrowType for the corresponding vector
+   * @param field ArrowType for the corresponding vector
    */
   public JdbcConsumerException(
-      String message, Throwable cause, JdbcFieldInfo fieldInfo, Types.MinorType minorType) {
+      String message, Throwable cause, JdbcFieldInfo fieldInfo, Field field) {
     super(message, cause);
     this.fieldInfo = fieldInfo;
-    this.minorType = minorType;
+    this.field = field;
   }
 
-  public Types.MinorType getMinorType() {
-    return this.minorType;
+  public Field getField() {
+    return this.field;
   }
 
   public JdbcFieldInfo getFieldInfo() {


### PR DESCRIPTION
## What's Changed

Turns out not all MinorTypes have a corresponding ArrowType, which can cause the following exception while handling the original exception:

```
Caused by: java.lang.UnsupportedOperationException: Cannot get simple type for type DECIMAL
	at org.apache.arrow.vector.types.Types$MinorType.getType(Types.java:815)
	at org.apache.arrow.adapter.jdbc.consumer.CompositeJdbcConsumer.consume(CompositeJdbcConsumer.java:49)
```

This PR changes the value we store in the exception to be the `MinorType` instead so we can still get useful info about the type but avoiding this possible exception.

Closes #858.
