### PR TITLE
Fix ARROW_STRUCT_CONFLICT_POLICY env not work

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -46,10 +46,12 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
   private ConflictPolicy conflictPolicy;
 
   static {
-    String conflictPolicyStr =
-        System.getProperty(STRUCT_CONFLICT_POLICY_JVM, ConflictPolicy.CONFLICT_REPLACE.toString());
+    String conflictPolicyStr = System.getProperty(STRUCT_CONFLICT_POLICY_JVM);
     if (conflictPolicyStr == null) {
       conflictPolicyStr = System.getenv(STRUCT_CONFLICT_POLICY_ENV);
+    }
+    if (conflictPolicyStr == null) {
+      conflictPolicyStr = ConflictPolicy.CONFLICT_REPLACE.toString();
     }
     ConflictPolicy conflictPolicy;
     try {


### PR DESCRIPTION
## What's Changed

Do not specify default value when getting the `arrow.struct.conflict.policy` property

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #859