### PR TITLE
macos-13 is deprecated

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -221,6 +221,10 @@ jobs:
           # llvm@14 because llvm is newer than llvm@14.
           brew uninstall llvm || :
 
+          # We can remove this when we drop support for
+          # macos-15-intel. because macos-14 or later with arm64 uses /opt/homebrew/
+          # not /usr/local/.
+          #
           # Ensure updating python@XXX with the "--overwrite" option.
           # If python@XXX is updated without "--overwrite", it causes
           # a conflict error. Because Python 3 installed not by
@@ -229,9 +233,10 @@ jobs:
           # tries to replace /usr/local/bin/2to3 and so on and causes
           # a conflict error.
           brew update
-          for python_package in $(brew list | grep python@); do
+          for python_package in $(brew list | grep python@ | sort -r); do
             brew install --overwrite ${python_package}
           done
+          brew install --overwrite python3
 
           if [ "$(uname -m)" = "arm64" ]; then
             # pkg-config formula is deprecated but it's still installed


### PR DESCRIPTION
## What's Changed
Closes #869

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

- update use of `macos-13`, replacing with `macos-15-intel` based on
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
- revert [previous commit](https://github.com/kevinjqliu/arrow-java/commit/abef7af8490d706d52821e56afc6d1eb21e24faf) specifically for fixing `macos-13`
