### PR TITLE
GH-875: [CI] Bump default Python version on .env so dependencies like archery are installable on CI

### DIFF
--- a/.env
+++ b/.env
@@ -53,5 +53,5 @@ MAVEN=3.9.9
 # Versions for various dependencies used to build artifacts
 # Keep in sync with apache/arrow
 ARROW_REPO_ROOT=./arrow
-PYTHON=3.9
+PYTHON=3.12
 VCPKG="f7423ee180c4b7f40d43402c2feb3859161ef625" # 2024.06.15 Release

--- a/compose.yaml
+++ b/compose.yaml
@@ -92,12 +92,12 @@ services:
     # Usage:
     #   docker compose build vcpkg-jni
     #   docker compose run vcpkg-jni
-    image: ${REPO}:${ARCH}-vcpkg-jni-${VCPKG}
+    image: ${REPO}:${ARCH}-vcpkg-jni-${PYTHON}-${VCPKG}
     build:
       context: .
       dockerfile: ci/docker/vcpkg-jni.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-vcpkg-jni-${VCPKG}
+        - ${REPO}:${ARCH}-vcpkg-jni-${PYTHON}-${VCPKG}
       args:
         base: ${ARROW_REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
     volumes:


### PR DESCRIPTION
## What's Changed

Update .env Python version that is used on the underlying docker images so it's compatible with minimum Python version for PyArrow/Archery.

Python 3.9 will be EOL on the next days.

Closes #875 
