### PR TITLE
GH-810: added support of ExtensionType for UnionVector

### DIFF
--- a/vector/src/main/codegen/includes/vv_imports.ftl
+++ b/vector/src/main/codegen/includes/vv_imports.ftl
@@ -43,6 +43,8 @@ import org.apache.arrow.vector.util.JsonStringArrayList;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import java.io.Closeable;
 import java.io.InputStream;

--- a/vector/src/main/codegen/templates/AbstractFieldReader.java
+++ b/vector/src/main/codegen/templates/AbstractFieldReader.java
@@ -109,7 +109,7 @@ abstract class AbstractFieldReader extends AbstractBaseReader implements FieldRe
 
   </#list></#list>
 
-  public void copyAsValue(StructWriter writer, ExtensionTypeWriterFactory writerFactory) {
+  public void copyAsValue(StructWriter writer, ExtensionTypeFactory writerFactory) {
     fail("CopyAsValue StructWriter");
   }
 

--- a/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -110,10 +110,10 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   public void write(ExtensionHolder var1)  {
     this.fail("ExtensionType");
   }
-  public void writeExtension(Object var1)  {
+  public void writeExtension(Object var1, ExtensionType var2)  {
     this.fail("ExtensionType");
   }
-  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory var1) {
+  public void addExtensionTypeWriterFactory(ExtensionTypeFactory var1, ExtensionType var2) {
     this.fail("ExtensionType");
   }
 

--- a/vector/src/main/codegen/templates/BaseReader.java
+++ b/vector/src/main/codegen/templates/BaseReader.java
@@ -49,7 +49,7 @@ public interface BaseReader extends Positionable{
     boolean next();
     int size();
     void copyAsValue(StructWriter writer);
-    void copyAsValue(StructWriter writer, ExtensionTypeWriterFactory writerFactory);
+    void copyAsValue(StructWriter writer, ExtensionTypeFactory writerFactory);
   }
 
   public interface ListReader extends BaseReader{
@@ -60,7 +60,7 @@ public interface BaseReader extends Positionable{
     boolean next();
     int size();
     void copyAsValue(ListWriter writer);
-    void copyAsValue(ListWriter writer, ExtensionTypeWriterFactory writerFactory);
+    void copyAsValue(ListWriter writer, ExtensionTypeFactory writerFactory);
   }
 
   public interface MapReader extends BaseReader{
@@ -71,7 +71,7 @@ public interface BaseReader extends Positionable{
     boolean next();
     int size();
     void copyAsValue(MapWriter writer);
-    void copyAsValue(MapWriter writer, ExtensionTypeWriterFactory writerFactory);
+    void copyAsValue(MapWriter writer, ExtensionTypeFactory writerFactory);
   }
 
   public interface ScalarReader extends

--- a/vector/src/main/codegen/templates/BaseWriter.java
+++ b/vector/src/main/codegen/templates/BaseWriter.java
@@ -122,14 +122,14 @@ public interface BaseWriter extends AutoCloseable, Positionable {
      *
      * @param value the extension type value to write
      */
-    void writeExtension(Object value);
+    void writeExtension(Object value, ExtensionType extensionType);
 
     /**
      * Adds the given extension type factory. This factory allows configuring writer implementations for specific ExtensionTypeVector.
      *
      * @param factory the extension type factory to add
      */
-    void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory);
+    void addExtensionTypeWriterFactory(ExtensionTypeFactory factory, ExtensionType extensionType);
   }
 
   public interface ScalarWriter extends

--- a/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/vector/src/main/codegen/templates/ComplexCopier.java
@@ -19,6 +19,7 @@ import org.apache.arrow.vector.complex.impl.UnionMapReader;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
 
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/ComplexCopier.java" />
@@ -45,11 +46,11 @@ public class ComplexCopier {
     writeValue(input, output, null);
   }
 
-  public static void copy(FieldReader input, FieldWriter output, ExtensionTypeWriterFactory extensionTypeWriterFactory) {
+  public static void copy(FieldReader input, FieldWriter output, ExtensionTypeFactory extensionTypeWriterFactory) {
     writeValue(input, output, extensionTypeWriterFactory);
   }
 
-  private static void writeValue(FieldReader reader, FieldWriter writer, ExtensionTypeWriterFactory extensionTypeWriterFactory) {
+  private static void writeValue(FieldReader reader, FieldWriter writer, ExtensionTypeFactory extensionTypeWriterFactory) {
     final MinorType mt = reader.getMinorType();
 
       switch (mt) {
@@ -120,9 +121,10 @@ public class ComplexCopier {
         }
         if (reader.isSet()) {
           Object value = reader.readObject();
+          ExtensionType extensionType = (ExtensionType) reader.getField().getType();
           if (value != null) {
-            writer.addExtensionTypeWriterFactory(extensionTypeWriterFactory);
-            writer.writeExtension(value);
+            writer.addExtensionTypeWriterFactory(extensionTypeWriterFactory, extensionType);
+            writer.writeExtension(value, extensionType);
           }
         } else {
           writer.writeNull();

--- a/vector/src/main/codegen/templates/NullReader.java
+++ b/vector/src/main/codegen/templates/NullReader.java
@@ -86,7 +86,7 @@ public class NullReader extends AbstractBaseReader implements FieldReader{
   }
   </#list></#list>
 
-  public void copyAsValue(StructWriter writer, ExtensionTypeWriterFactory writerFactory){}
+  public void copyAsValue(StructWriter writer, ExtensionTypeFactory writerFactory){}
   public void read(ExtensionHolder holder) {
     holder.isSet = 0;
   }

--- a/vector/src/main/codegen/templates/PromotableWriter.java
+++ b/vector/src/main/codegen/templates/PromotableWriter.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-<@pp.dropOutputFile />
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/PromotableWriter.java" />
 
 <#include "/@includes/license.ftl" />
@@ -541,17 +542,13 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   }
 
   @Override
-  public void writeExtension(Object value) {
-    getWriter(MinorType.EXTENSIONTYPE).writeExtension(value);
+  public void writeExtension(Object value, ExtensionType extensionType) {
+    getWriter(MinorType.EXTENSIONTYPE, extensionType).writeExtension(value, extensionType);
   }
 
   @Override
-  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory) {
-    getWriter(MinorType.EXTENSIONTYPE).addExtensionTypeWriterFactory(factory);
-  }
-
-  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory, ArrowType arrowType) {
-    getWriter(MinorType.EXTENSIONTYPE, arrowType).addExtensionTypeWriterFactory(factory);
+  public void addExtensionTypeWriterFactory(ExtensionTypeFactory var1, ExtensionType var2) {
+    getWriter(MinorType.EXTENSIONTYPE, var2).addExtensionTypeWriterFactory(var1, var2);
   }
 
   @Override

--- a/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/vector/src/main/codegen/templates/UnionListWriter.java
@@ -16,6 +16,7 @@
  */
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.writer.Decimal256Writer;
 import org.apache.arrow.vector.complex.writer.DecimalWriter;
 import org.apache.arrow.vector.holders.Decimal256Holder;
@@ -24,6 +25,7 @@ import org.apache.arrow.vector.holders.DecimalHolder;
 
 import java.lang.UnsupportedOperationException;
 import java.math.BigDecimal;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
 
 <@pp.dropOutputFile />
 <#list ["List", "ListView", "LargeList", "LargeListView"] as listName>
@@ -336,14 +338,14 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   }
 
   @Override
-  public void writeExtension(Object value) {
-    writer.writeExtension(value);
+  public void writeExtension(Object value, ExtensionType extensionType) {
+    writer.writeExtension(value, extensionType);
     writer.setPosition(writer.idx() + 1);
   }
 
   @Override
-  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory var1) {
-    writer.addExtensionTypeWriterFactory(var1, extensionType);
+  public void addExtensionTypeWriterFactory(ExtensionTypeFactory var1, ExtensionType var2) {
+    writer.addExtensionTypeWriterFactory(var1, var2);
   }
 
   public void write(ExtensionHolder var1) {

--- a/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -22,7 +22,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.util.DataSizeRoundingUtil;
 import org.apache.arrow.vector.util.TransferPair;
@@ -263,13 +263,13 @@ public abstract class BaseValueVector implements ValueVector {
 
   @Override
   public void copyFrom(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public void copyFromSafe(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException();
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -24,6 +24,7 @@ import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.holders.ExtensionHolder;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -287,4 +288,6 @@ public abstract class ExtensionTypeVector<T extends ValueVector & FieldVector>
   public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
     return visitor.visit(this, value);
   }
+
+  public abstract void setSafe(int index, ExtensionHolder holder);
 }

--- a/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -27,7 +27,7 @@ import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.impl.NullReader;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -332,13 +332,13 @@ public class NullVector implements FieldVector, ValueIterableVector<Object> {
 
   @Override
   public void copyFrom(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public void copyFromSafe(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException();
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -22,7 +22,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.compare.VectorVisitor;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -319,8 +319,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
    * @param from source vector
    * @param writerFactory the extension type writer factory to use for copying extension type values
    */
-  void copyFrom(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory);
+  void copyFrom(int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory);
 
   /**
    * Same as {@link #copyFrom(int, int, ValueVector)} except that it handles the case when the
@@ -332,7 +331,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
    * @param writerFactory the extension type writer factory to use for copying extension type values
    */
   void copyFromSafe(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory);
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory);
 
   /**
    * Accept a generic {@link VectorVisitor} and return the result.

--- a/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
@@ -21,7 +21,7 @@ import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeList;
@@ -154,13 +154,13 @@ public abstract class AbstractContainerVector implements ValueVector, DensityAwa
 
   @Override
   public void copyFrom(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public void copyFromSafe(
-      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int fromIndex, int thisIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException();
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/complex/BaseLargeRepeatedValueViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/BaseLargeRepeatedValueViewVector.java
@@ -347,6 +347,7 @@ public abstract class BaseLargeRepeatedValueViewVector extends BaseValueVector
    * Initialize the data vector (and execute callback) if it hasn't already been done, returns the
    * data vector.
    */
+  @SuppressWarnings("unchecked")
   public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType fieldType) {
     boolean created = false;
     if (vector instanceof NullVector) {

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -49,7 +49,7 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.impl.UnionLargeListReader;
 import org.apache.arrow.vector.complex.impl.UnionLargeListWriter;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -497,7 +497,7 @@ public class LargeListVector extends BaseValueVector
    */
   @Override
   public void copyFrom(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     FieldReader in = from.getReader();
     in.setPosition(inIndex);
@@ -517,7 +517,7 @@ public class LargeListVector extends BaseValueVector
    */
   @Override
   public void copyFromSafe(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     copyFrom(inIndex, outIndex, from, writerFactory);
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
@@ -41,7 +41,7 @@ import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.impl.UnionLargeListViewReader;
 import org.apache.arrow.vector.complex.impl.UnionLargeListViewWriter;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
@@ -349,14 +349,14 @@ public class LargeListViewVector extends BaseLargeRepeatedValueViewVector
 
   @Override
   public void copyFromSafe(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException(
         "LargeListViewVector does not support copyFromSafe operation yet.");
   }
 
   @Override
   public void copyFrom(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     throw new UnsupportedOperationException(
         "LargeListViewVector does not support copyFrom operation yet.");
   }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -42,7 +42,7 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -415,7 +415,7 @@ public class ListVector extends BaseRepeatedValueVector
    */
   @Override
   public void copyFromSafe(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     copyFrom(inIndex, outIndex, from, writerFactory);
   }
 
@@ -430,7 +430,7 @@ public class ListVector extends BaseRepeatedValueVector
    */
   @Override
   public void copyFrom(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     FieldReader in = from.getReader();
     in.setPosition(inIndex);

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
@@ -42,7 +42,7 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
-import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeFactory;
 import org.apache.arrow.vector.complex.impl.UnionListViewReader;
 import org.apache.arrow.vector.complex.impl.UnionListViewWriter;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -341,7 +341,7 @@ public class ListViewVector extends BaseRepeatedValueViewVector
 
   @Override
   public void copyFromSafe(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     copyFrom(inIndex, outIndex, from, writerFactory);
   }
 
@@ -357,7 +357,7 @@ public class ListViewVector extends BaseRepeatedValueViewVector
 
   @Override
   public void copyFrom(
-      int inIndex, int outIndex, ValueVector from, ExtensionTypeWriterFactory writerFactory) {
+      int inIndex, int outIndex, ValueVector from, ExtensionTypeFactory writerFactory) {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     FieldReader in = from.getReader();
     in.setPosition(inIndex);

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
@@ -117,12 +117,12 @@ abstract class AbstractBaseReader implements FieldReader {
   }
 
   @Override
-  public void copyAsValue(ListWriter writer, ExtensionTypeWriterFactory writerFactory) {
+  public void copyAsValue(ListWriter writer, ExtensionTypeFactory writerFactory) {
     ComplexCopier.copy(this, (FieldWriter) writer, writerFactory);
   }
 
   @Override
-  public void copyAsValue(MapWriter writer, ExtensionTypeWriterFactory writerFactory) {
+  public void copyAsValue(MapWriter writer, ExtensionTypeFactory writerFactory) {
     ComplexCopier.copy(this, (FieldWriter) writer, writerFactory);
   }
 }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeFactory.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeFactory.java
@@ -17,15 +17,12 @@
 package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
+import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
 
-/**
- * A factory interface for creating instances of {@link ExtensionTypeWriter}. This factory allows
- * configuring writer implementations for specific {@link ExtensionTypeVector}.
- *
- * @param <T> the type of writer implementation for a specific {@link ExtensionTypeVector}.
- */
-public interface ExtensionTypeWriterFactory<T extends FieldWriter> {
+public interface ExtensionTypeFactory {
 
   /**
    * Returns an instance of the writer implementation for the given {@link ExtensionTypeVector}.
@@ -34,5 +31,11 @@ public interface ExtensionTypeWriterFactory<T extends FieldWriter> {
    *     returned.
    * @return an instance of the writer implementation for the given {@link ExtensionTypeVector}.
    */
-  T getWriterImpl(ExtensionTypeVector vector);
+  FieldWriter getWriterImpl(ExtensionTypeVector vector);
+
+  Class<? extends ExtensionTypeVector> getVectorClass(ExtensionType extensionType);
+
+  FieldReader getReaderImpl(ExtensionTypeVector vector);
+
+  ExtensionType getExtensionTypeByHolder(ExtensionHolder holder);
 }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector.complex.impl;
 import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
 import org.apache.arrow.vector.types.pojo.Field;
 
 public class UnionExtensionWriter extends AbstractFieldWriter {
@@ -55,12 +56,13 @@ public class UnionExtensionWriter extends AbstractFieldWriter {
   }
 
   @Override
-  public void writeExtension(Object var1) {
-    this.writer.writeExtension(var1);
+  public void writeExtension(Object var1, ExtensionType var2) {
+    this.writer.writeExtension(var1, var2);
   }
 
   @Override
-  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory) {
+  public void addExtensionTypeWriterFactory(
+      ExtensionTypeFactory factory, ExtensionType extensionType) {
     this.writer = factory.getWriterImpl(vector);
     this.writer.setPosition(idx());
   }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionLargeListReader.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionLargeListReader.java
@@ -106,7 +106,7 @@ public class UnionLargeListReader extends AbstractFieldReader {
     ComplexCopier.copy(this, (FieldWriter) writer);
   }
 
-  public void copyAsValue(UnionLargeListWriter writer, ExtensionTypeWriterFactory writerFactory) {
+  public void copyAsValue(UnionLargeListWriter writer, ExtensionTypeFactory writerFactory) {
     ComplexCopier.copy(this, (FieldWriter) writer, writerFactory);
   }
 }

--- a/vector/src/main/java/org/apache/arrow/vector/extension/OpaqueVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/extension/OpaqueVector.java
@@ -21,6 +21,7 @@ import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueIterableVector;
+import org.apache.arrow.vector.holders.ExtensionHolder;
 import org.apache.arrow.vector.types.pojo.Field;
 
 /**
@@ -44,6 +45,11 @@ public class OpaqueVector extends ExtensionTypeVector<FieldVector>
   @Override
   public Object getObject(int index) {
     return getUnderlyingVector().getObject(index);
+  }
+
+  @Override
+  public void setSafe(int index, ExtensionHolder holder) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
-import org.apache.arrow.vector.complex.impl.UuidWriterFactory;
+import org.apache.arrow.vector.complex.impl.UuidFactory;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
 import org.apache.arrow.vector.holder.UuidHolder;
@@ -1208,7 +1208,8 @@ public class TestListVector {
 
   @Test
   public void testListVectorWithExtensionType() throws Exception {
-    final FieldType type = FieldType.nullable(new UuidType());
+    UuidType uuidType = new UuidType();
+    final FieldType type = FieldType.nullable(uuidType);
     try (final ListVector inVector = new ListVector("list", allocator, type, null)) {
       UnionListWriter writer = inVector.getWriter();
       writer.allocate();
@@ -1216,10 +1217,10 @@ public class TestListVector {
       UUID u1 = UUID.randomUUID();
       UUID u2 = UUID.randomUUID();
       writer.startList();
-      ExtensionWriter extensionWriter = writer.extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u1);
-      extensionWriter.writeExtension(u2);
+      ExtensionWriter extensionWriter = writer.extension(uuidType);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+      extensionWriter.writeExtension(u1, uuidType);
+      extensionWriter.writeExtension(u2, uuidType);
       writer.endList();
 
       writer.setValueCount(1);
@@ -1236,7 +1237,8 @@ public class TestListVector {
 
   @Test
   public void testListVectorReaderForExtensionType() throws Exception {
-    final FieldType type = FieldType.nullable(new UuidType());
+    UuidType uuidType = new UuidType();
+    final FieldType type = FieldType.nullable(uuidType);
     try (final ListVector inVector = new ListVector("list", allocator, type, null)) {
       UnionListWriter writer = inVector.getWriter();
       writer.allocate();
@@ -1244,10 +1246,10 @@ public class TestListVector {
       UUID u1 = UUID.randomUUID();
       UUID u2 = UUID.randomUUID();
       writer.startList();
-      ExtensionWriter extensionWriter = writer.extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u1);
-      extensionWriter.writeExtension(u2);
+      ExtensionWriter extensionWriter = writer.extension(uuidType);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+      extensionWriter.writeExtension(u1, uuidType);
+      extensionWriter.writeExtension(u2, uuidType);
       writer.endList();
 
       writer.setValueCount(1);
@@ -1273,6 +1275,7 @@ public class TestListVector {
 
   @Test
   public void testCopyFromForExtensionType() throws Exception {
+    UuidType uuidType = new UuidType();
     try (ListVector inVector = ListVector.empty("input", allocator);
         ListVector outVector = ListVector.empty("output", allocator)) {
       UnionListWriter writer = inVector.getWriter();
@@ -1281,10 +1284,10 @@ public class TestListVector {
       UUID u1 = UUID.randomUUID();
       UUID u2 = UUID.randomUUID();
       writer.startList();
-      ExtensionWriter extensionWriter = writer.extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u1);
-      extensionWriter.writeExtension(u2);
+      ExtensionWriter extensionWriter = writer.extension(uuidType);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+      extensionWriter.writeExtension(u1, uuidType);
+      extensionWriter.writeExtension(u2, uuidType);
       extensionWriter.writeNull();
       writer.endList();
 
@@ -1292,7 +1295,7 @@ public class TestListVector {
 
       // copy values from input to output
       outVector.allocateNew();
-      outVector.copyFrom(0, 0, inVector, new UuidWriterFactory());
+      outVector.copyFrom(0, 0, inVector, new UuidFactory());
       outVector.setValueCount(1);
 
       UnionListReader reader = outVector.getReader();

--- a/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.impl.UnionMapReader;
 import org.apache.arrow.vector.complex.impl.UnionMapWriter;
-import org.apache.arrow.vector.complex.impl.UuidWriterFactory;
+import org.apache.arrow.vector.complex.impl.UuidFactory;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
@@ -1272,6 +1272,7 @@ public class TestMapVector {
 
   @Test
   public void testMapVectorWithExtensionType() throws Exception {
+    UuidType uuidType = new UuidType();
     try (final MapVector inVector = MapVector.empty("map", allocator, false)) {
       inVector.allocateNew();
       UnionMapWriter writer = inVector.getWriter();
@@ -1281,15 +1282,15 @@ public class TestMapVector {
       writer.startMap();
       writer.startEntry();
       writer.key().bigInt().writeBigInt(0);
-      ExtensionWriter extensionWriter = writer.value().extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u1);
+      ExtensionWriter extensionWriter = writer.value().extension(uuidType);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+      extensionWriter.writeExtension(u1, uuidType);
       writer.endEntry();
       writer.startEntry();
       writer.key().bigInt().writeBigInt(1);
       extensionWriter = writer.value().extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u2);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), new UuidType());
+      extensionWriter.writeExtension(u2, uuidType);
       writer.endEntry();
       writer.endMap();
 
@@ -1315,6 +1316,8 @@ public class TestMapVector {
 
   @Test
   public void testCopyFromForExtensionType() throws Exception {
+    UuidType uuidType = new UuidType();
+
     try (final MapVector inVector = MapVector.empty("in", allocator, false);
         final MapVector outVector = MapVector.empty("out", allocator, false)) {
       inVector.allocateNew();
@@ -1325,21 +1328,21 @@ public class TestMapVector {
       writer.startMap();
       writer.startEntry();
       writer.key().bigInt().writeBigInt(0);
-      ExtensionWriter extensionWriter = writer.value().extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u1);
+      ExtensionWriter extensionWriter = writer.value().extension(uuidType);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+      extensionWriter.writeExtension(u1, uuidType);
       writer.endEntry();
       writer.startEntry();
       writer.key().bigInt().writeBigInt(1);
       extensionWriter = writer.value().extension(new UuidType());
-      extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-      extensionWriter.writeExtension(u2);
+      extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), new UuidType());
+      extensionWriter.writeExtension(u2, uuidType);
       writer.endEntry();
       writer.endMap();
 
       writer.setValueCount(1);
       outVector.allocateNew();
-      outVector.copyFrom(0, 0, inVector, new UuidWriterFactory());
+      outVector.copyFrom(0, 0, inVector, new UuidFactory());
       outVector.setValueCount(1);
 
       UnionMapReader mapReader = outVector.getReader();

--- a/vector/src/test/java/org/apache/arrow/vector/UuidVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/UuidVector.java
@@ -23,6 +23,7 @@ import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.complex.impl.UuidReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holder.UuidHolder;
+import org.apache.arrow.vector.holders.ExtensionHolder;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.UuidType;
@@ -47,6 +48,12 @@ public class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector>
   public UUID getObject(int index) {
     final ByteBuffer bb = ByteBuffer.wrap(getUnderlyingVector().getObject(index));
     return new UUID(bb.getLong(), bb.getLong());
+  }
+
+  @Override
+  public void setSafe(int index, ExtensionHolder holder) {
+    UuidHolder uuidHolder = (UuidHolder) holder;
+    setSafe(index, uuidHolder.value);
   }
 
   @Override

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -851,6 +851,7 @@ public class TestComplexCopier {
 
   @Test
   public void testCopyListVectorWithExtensionType() {
+    UuidType uuidType = new UuidType();
     try (ListVector from = ListVector.empty("v", allocator);
         ListVector to = ListVector.empty("v", allocator)) {
 
@@ -860,10 +861,10 @@ public class TestComplexCopier {
       for (int i = 0; i < COUNT; i++) {
         listWriter.setPosition(i);
         listWriter.startList();
-        ExtensionWriter extensionWriter = listWriter.extension(new UuidType());
-        extensionWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-        extensionWriter.writeExtension(UUID.randomUUID());
-        extensionWriter.writeExtension(UUID.randomUUID());
+        ExtensionWriter extensionWriter = listWriter.extension(uuidType);
+        extensionWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+        extensionWriter.writeExtension(UUID.randomUUID(), uuidType);
+        extensionWriter.writeExtension(UUID.randomUUID(), uuidType);
         listWriter.endList();
       }
       from.setValueCount(COUNT);
@@ -874,7 +875,7 @@ public class TestComplexCopier {
       for (int i = 0; i < COUNT; i++) {
         in.setPosition(i);
         out.setPosition(i);
-        ComplexCopier.copy(in, out, new UuidWriterFactory());
+        ComplexCopier.copy(in, out, new UuidFactory());
       }
 
       to.setValueCount(COUNT);
@@ -886,6 +887,7 @@ public class TestComplexCopier {
 
   @Test
   public void testCopyMapVectorWithExtensionType() {
+    UuidType uuidType = new UuidType();
     try (final MapVector from = MapVector.empty("v", allocator, false);
         final MapVector to = MapVector.empty("v", allocator, false)) {
 
@@ -896,12 +898,12 @@ public class TestComplexCopier {
         mapWriter.setPosition(i);
         mapWriter.startMap();
         mapWriter.startEntry();
-        ExtensionWriter extensionKeyWriter = mapWriter.key().extension(new UuidType());
-        extensionKeyWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-        extensionKeyWriter.writeExtension(UUID.randomUUID());
-        ExtensionWriter extensionValueWriter = mapWriter.value().extension(new UuidType());
-        extensionValueWriter.addExtensionTypeWriterFactory(new UuidWriterFactory());
-        extensionValueWriter.writeExtension(UUID.randomUUID());
+        ExtensionWriter extensionKeyWriter = mapWriter.key().extension(uuidType);
+        extensionKeyWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+        extensionKeyWriter.writeExtension(UUID.randomUUID(), uuidType);
+        ExtensionWriter extensionValueWriter = mapWriter.value().extension(uuidType);
+        extensionValueWriter.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+        extensionValueWriter.writeExtension(UUID.randomUUID(), uuidType);
         mapWriter.endEntry();
         mapWriter.endMap();
       }
@@ -914,7 +916,7 @@ public class TestComplexCopier {
       for (int i = 0; i < COUNT; i++) {
         in.setPosition(i);
         out.setPosition(i);
-        ComplexCopier.copy(in, out, new UuidWriterFactory());
+        ComplexCopier.copy(in, out, new UuidFactory());
       }
       to.setValueCount(COUNT);
 
@@ -925,6 +927,7 @@ public class TestComplexCopier {
 
   @Test
   public void testCopyStructVectorWithExtensionType() {
+    UuidType uuidType = new UuidType();
     try (final StructVector from = StructVector.empty("v", allocator);
         final StructVector to = StructVector.empty("v", allocator)) {
 
@@ -934,12 +937,12 @@ public class TestComplexCopier {
       for (int i = 0; i < COUNT; i++) {
         structWriter.setPosition(i);
         structWriter.start();
-        ExtensionWriter extensionWriter1 = structWriter.extension("timestamp1", new UuidType());
-        extensionWriter1.addExtensionTypeWriterFactory(new UuidWriterFactory());
-        extensionWriter1.writeExtension(UUID.randomUUID());
-        ExtensionWriter extensionWriter2 = structWriter.extension("timestamp2", new UuidType());
-        extensionWriter2.addExtensionTypeWriterFactory(new UuidWriterFactory());
-        extensionWriter2.writeExtension(UUID.randomUUID());
+        ExtensionWriter extensionWriter1 = structWriter.extension("timestamp1", uuidType);
+        extensionWriter1.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+        extensionWriter1.writeExtension(UUID.randomUUID(), uuidType);
+        ExtensionWriter extensionWriter2 = structWriter.extension("timestamp2", uuidType);
+        extensionWriter2.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
+        extensionWriter2.writeExtension(UUID.randomUUID(), uuidType);
         structWriter.end();
       }
 
@@ -951,7 +954,7 @@ public class TestComplexCopier {
       for (int i = 0; i < COUNT; i++) {
         in.setPosition(i);
         out.setPosition(i);
-        ComplexCopier.copy(in, out, new UuidWriterFactory());
+        ComplexCopier.copy(in, out, new UuidFactory());
       }
       to.setValueCount(COUNT);
 

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
@@ -782,21 +782,22 @@ public class TestPromotableWriter {
 
   @Test
   public void testExtensionType() throws Exception {
+    UuidType uuidType = new UuidType();
     try (final NonNullableStructVector container =
             NonNullableStructVector.empty(EMPTY_SCHEMA_PATH, allocator);
         final UuidVector v =
-            container.addOrGet("uuid", FieldType.nullable(new UuidType()), UuidVector.class);
+            container.addOrGet("uuid", FieldType.nullable(uuidType), UuidVector.class);
         final PromotableWriter writer = new PromotableWriter(v, container)) {
       UUID u1 = UUID.randomUUID();
       UUID u2 = UUID.randomUUID();
       container.allocateNew();
       container.setValueCount(1);
-      writer.addExtensionTypeWriterFactory(new UuidWriterFactory());
+      writer.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
 
       writer.setPosition(0);
-      writer.writeExtension(u1);
+      writer.writeExtension(u1, uuidType);
       writer.setPosition(1);
-      writer.writeExtension(u2);
+      writer.writeExtension(u2, uuidType);
 
       container.setValueCount(2);
 
@@ -808,20 +809,21 @@ public class TestPromotableWriter {
 
   @Test
   public void testExtensionTypeForList() throws Exception {
+    UuidType uuidType = new UuidType();
     try (final ListVector container = ListVector.empty(EMPTY_SCHEMA_PATH, allocator);
         final UuidVector v =
-            (UuidVector) container.addOrGetVector(FieldType.nullable(new UuidType())).getVector();
+            (UuidVector) container.addOrGetVector(FieldType.nullable(uuidType)).getVector();
         final PromotableWriter writer = new PromotableWriter(v, container)) {
       UUID u1 = UUID.randomUUID();
       UUID u2 = UUID.randomUUID();
       container.allocateNew();
       container.setValueCount(1);
-      writer.addExtensionTypeWriterFactory(new UuidWriterFactory());
+      writer.addExtensionTypeWriterFactory(new UuidFactory(), uuidType);
 
       writer.setPosition(0);
-      writer.writeExtension(u1);
+      writer.writeExtension(u1, uuidType);
       writer.setPosition(1);
-      writer.writeExtension(u2);
+      writer.writeExtension(u2, uuidType);
 
       container.setValueCount(2);
 

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidFactory.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidFactory.java
@@ -18,13 +18,41 @@ package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.UuidVector;
+import org.apache.arrow.vector.holder.UuidHolder;
+import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
+import org.apache.arrow.vector.types.pojo.UuidType;
 
-public class UuidWriterFactory implements ExtensionTypeWriterFactory {
+public class UuidFactory implements ExtensionTypeFactory {
 
   @Override
   public AbstractFieldWriter getWriterImpl(ExtensionTypeVector extensionTypeVector) {
     if (extensionTypeVector instanceof UuidVector) {
       return new UuidWriterImpl((UuidVector) extensionTypeVector);
+    }
+    return null;
+  }
+
+  @Override
+  public Class<? extends ExtensionTypeVector> getVectorClass(ExtensionType extensionType) {
+    if (extensionType instanceof UuidType) {
+      return UuidVector.class;
+    }
+    throw new UnsupportedOperationException("Unsupported extension type " + extensionType);
+  }
+
+  @Override
+  public ExtensionType getExtensionTypeByHolder(ExtensionHolder holder) {
+    if (holder instanceof UuidHolder) {
+      return new UuidType();
+    }
+    return null;
+  }
+
+  @Override
+  public AbstractFieldReader getReaderImpl(ExtensionTypeVector extensionTypeVector) {
+    if (extensionTypeVector instanceof UuidVector) {
+      return new UuidReaderImpl((UuidVector) extensionTypeVector);
     }
     return null;
   }

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidWriterImpl.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidWriterImpl.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.apache.arrow.vector.UuidVector;
 import org.apache.arrow.vector.holder.UuidHolder;
 import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
 
 public class UuidWriterImpl extends AbstractExtensionTypeWriter<UuidVector> {
 
@@ -29,7 +30,7 @@ public class UuidWriterImpl extends AbstractExtensionTypeWriter<UuidVector> {
   }
 
   @Override
-  public void writeExtension(Object value) {
+  public void writeExtension(Object value, ExtensionType extensionType) {
     UUID uuid = (UUID) value;
     ByteBuffer bb = ByteBuffer.allocate(16);
     bb.putLong(uuid.getMostSignificantBits());

--- a/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -47,6 +47,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.holders.ExtensionHolder;
 import org.apache.arrow.vector.ipc.ArrowFileReader;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
@@ -367,6 +368,11 @@ public class TestExtensionType {
     @Override
     public java.util.Map<String, ?> getObject(int index) {
       return getUnderlyingVector().getObject(index);
+    }
+
+    @Override
+    public void setSafe(int index, ExtensionHolder holder) {
+      throw new UnsupportedOperationException();
     }
 
     public void set(int index, float latitude, float longitude) {


### PR DESCRIPTION
## What's Changed

- Updated UnionVector, UnionWriter, and UnionReader to support ExtensionType.
- ExtensionTypeWriterFactory was renamed to ExtensionTypeFactory because it currently contains more methods and not only for writers.
- updated tests. 

Closes #810.
