### PR TITLE
Ensure the driver timezone is always respected

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcCursor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcCursor.java
@@ -55,18 +55,19 @@ public class ArrowFlightJdbcCursor extends AbstractCursor {
 
     return IntStream.range(0, fieldVectors.size())
         .mapToObj(root::getVector)
-        .map(this::createAccessor)
+        .map(v -> this.createAccessor(v, localCalendar))
         .collect(Collectors.toCollection(() -> new ArrayList<>(fieldVectors.size())));
   }
 
-  private Accessor createAccessor(FieldVector vector) {
+  private Accessor createAccessor(FieldVector vector, Calendar localCalendar) {
     return ArrowFlightJdbcAccessorFactory.createAccessor(
         vector,
         this::getCurrentRow,
         (boolean wasNull) -> {
           // AbstractCursor creates a boolean array of length 1 to hold the wasNull value
           this.wasNull[0] = wasNull;
-        });
+        },
+        localCalendar);
   }
 
   /**

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
@@ -19,6 +19,7 @@ package org.apache.arrow.driver.jdbc;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -28,14 +29,17 @@ import org.apache.arrow.driver.jdbc.utils.ConvertUtils;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaResultSet;
 import org.apache.calcite.avatica.AvaticaResultSetMetaData;
+import org.apache.calcite.avatica.AvaticaSite;
 import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.Meta.Frame;
 import org.apache.calcite.avatica.Meta.Signature;
 import org.apache.calcite.avatica.QueryState;
+import org.apache.calcite.avatica.util.Cursor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +104,33 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
 
     this.vectorSchemaRoot = vectorSchemaRoot;
     execute2(new ArrowFlightJdbcCursor(vectorSchemaRoot), this.signature.columns);
+  }
+
+  /**
+   * The default method in AvaticaResultSet does not properly handle TIMESTASMP_WITH_TIMEZONE, so we
+   * override here to add support.
+   *
+   * @param columnIndex the first column is 1, the second is 2, ...
+   * @return
+   * @throws SQLException
+   */
+  @Override
+  public Object getObject(int columnIndex) throws SQLException {
+    this.checkOpen();
+
+    Cursor.Accessor accessor;
+    try {
+      accessor = accessorList.get(columnIndex - 1);
+    } catch (IndexOutOfBoundsException var3) {
+      throw AvaticaConnection.HELPER.createException("invalid column ordinal: " + columnIndex);
+    }
+
+    ColumnMetaData metaData = columnMetaDataList.get(columnIndex - 1);
+    if (metaData.type.id == Types.TIMESTAMP_WITH_TIMEZONE) {
+      return accessor.getTimestamp(localCalendar);
+    } else {
+      return AvaticaSite.get(accessor, metaData.type.id, localCalendar);
+    }
   }
 
   @Override

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
@@ -121,7 +121,7 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
     Cursor.Accessor accessor;
     try {
       accessor = accessorList.get(columnIndex - 1);
-    } catch (IndexOutOfBoundsException var3) {
+    } catch (IndexOutOfBoundsException e) {
       throw AvaticaConnection.HELPER.createException("invalid column ordinal: " + columnIndex);
     }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
@@ -20,6 +20,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -68,10 +69,10 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
    * @return a ResultSet which accesses the given VectorSchemaRoot
    */
   public static ArrowFlightJdbcVectorSchemaRootResultSet fromVectorSchemaRoot(
-      final VectorSchemaRoot vectorSchemaRoot) throws SQLException {
+      final VectorSchemaRoot vectorSchemaRoot, Calendar localCalendar) throws SQLException {
     // Similar to how org.apache.calcite.avatica.util.ArrayFactoryImpl does
 
-    final TimeZone timeZone = TimeZone.getDefault();
+    final TimeZone timeZone = localCalendar.getTimeZone();
     final QueryState state = new QueryState();
 
     final Meta.Signature signature = ArrowFlightMetaImpl.newSignature(null, null, null);

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
@@ -111,8 +111,8 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
    * override here to add support.
    *
    * @param columnIndex the first column is 1, the second is 2, ...
-   * @return
-   * @throws SQLException
+   * @return Object
+   * @throws SQLException if there is an underlying exception
    */
   @Override
   public Object getObject(int columnIndex) throws SQLException {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactory.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor;
 
+import java.util.Calendar;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.impl.ArrowFlightJdbcNullVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.binary.ArrowFlightJdbcBinaryVectorAccessor;
@@ -87,7 +88,10 @@ public class ArrowFlightJdbcAccessorFactory {
    * @return an instance of one of the accessors.
    */
   public static ArrowFlightJdbcAccessor createAccessor(
-      ValueVector vector, IntSupplier getCurrentRow, WasNullConsumer setCursorWasNull) {
+      ValueVector vector,
+      IntSupplier getCurrentRow,
+      WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
     if (vector instanceof UInt1Vector) {
       return new ArrowFlightJdbcBaseIntVectorAccessor(
           (UInt1Vector) vector, getCurrentRow, setCursorWasNull);
@@ -138,7 +142,7 @@ public class ArrowFlightJdbcAccessorFactory {
           (FixedSizeBinaryVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TimeStampVector) {
       return new ArrowFlightJdbcTimeStampVectorAccessor(
-          (TimeStampVector) vector, getCurrentRow, setCursorWasNull);
+          (TimeStampVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof TimeNanoVector) {
       return new ArrowFlightJdbcTimeVectorAccessor(
           (TimeNanoVector) vector, getCurrentRow, setCursorWasNull);
@@ -180,22 +184,22 @@ public class ArrowFlightJdbcAccessorFactory {
           (StructVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof MapVector) {
       return new ArrowFlightJdbcMapVectorAccessor(
-          (MapVector) vector, getCurrentRow, setCursorWasNull);
+          (MapVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof ListVector) {
       return new ArrowFlightJdbcListVectorAccessor(
-          (ListVector) vector, getCurrentRow, setCursorWasNull);
+          (ListVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof LargeListVector) {
       return new ArrowFlightJdbcLargeListVectorAccessor(
-          (LargeListVector) vector, getCurrentRow, setCursorWasNull);
+          (LargeListVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof FixedSizeListVector) {
       return new ArrowFlightJdbcFixedSizeListVectorAccessor(
-          (FixedSizeListVector) vector, getCurrentRow, setCursorWasNull);
+          (FixedSizeListVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof UnionVector) {
       return new ArrowFlightJdbcUnionVectorAccessor(
-          (UnionVector) vector, getCurrentRow, setCursorWasNull);
+          (UnionVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof DenseUnionVector) {
       return new ArrowFlightJdbcDenseUnionVectorAccessor(
-          (DenseUnionVector) vector, getCurrentRow, setCursorWasNull);
+          (DenseUnionVector) vector, getCurrentRow, setCursorWasNull, localCalendar);
     } else if (vector instanceof NullVector || vector == null) {
       return new ArrowFlightJdbcNullVectorAccessor(setCursorWasNull);
     }

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListVectorAccessor.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.sql.Array;
+import java.util.Calendar;
 import java.util.List;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.ArrowFlightJdbcArray;
@@ -33,10 +34,14 @@ import org.apache.arrow.vector.complex.ListVector;
  */
 public abstract class AbstractArrowFlightJdbcListVectorAccessor extends ArrowFlightJdbcAccessor {
 
+  private final Calendar localCalendar;
+
   protected AbstractArrowFlightJdbcListVectorAccessor(
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
     super(currentRowSupplier, setCursorWasNull);
+    this.localCalendar = localCalendar;
   }
 
   @Override
@@ -67,6 +72,6 @@ public abstract class AbstractArrowFlightJdbcListVectorAccessor extends ArrowFli
     long endOffset = getEndOffset(index);
 
     long valuesCount = endOffset - startOffset;
-    return new ArrowFlightJdbcArray(dataVector, startOffset, valuesCount);
+    return new ArrowFlightJdbcArray(dataVector, startOffset, valuesCount, localCalendar);
   }
 }

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessor.java
@@ -50,13 +50,17 @@ public abstract class AbstractArrowFlightJdbcUnionVectorAccessor extends ArrowFl
    */
   private final ArrowFlightJdbcAccessor[] accessors = new ArrowFlightJdbcAccessor[128];
 
+  protected final Calendar localCalendar;
+
   private final ArrowFlightJdbcNullVectorAccessor nullAccessor =
       new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {});
 
   protected AbstractArrowFlightJdbcUnionVectorAccessor(
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
     super(currentRowSupplier, setCursorWasNull);
+    this.localCalendar = localCalendar;
   }
 
   protected abstract ArrowFlightJdbcAccessor createAccessorForVector(ValueVector vector);

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import java.util.Calendar;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -38,15 +39,19 @@ public class ArrowFlightJdbcDenseUnionVectorAccessor
   public ArrowFlightJdbcDenseUnionVectorAccessor(
       DenseUnionVector vector,
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
-    super(currentRowSupplier, setCursorWasNull);
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
+    super(currentRowSupplier, setCursorWasNull, localCalendar);
     this.vector = vector;
   }
 
   @Override
   protected ArrowFlightJdbcAccessor createAccessorForVector(ValueVector vector) {
     return ArrowFlightJdbcAccessorFactory.createAccessor(
-        vector, () -> this.vector.getOffset(this.getCurrentRow()), (boolean wasNull) -> {});
+        vector,
+        () -> this.vector.getOffset(this.getCurrentRow()),
+        (boolean wasNull) -> {},
+        localCalendar);
   }
 
   @Override

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcFixedSizeListVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcFixedSizeListVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -31,8 +32,9 @@ public class ArrowFlightJdbcFixedSizeListVectorAccessor
   public ArrowFlightJdbcFixedSizeListVectorAccessor(
       FixedSizeListVector vector,
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
-    super(currentRowSupplier, setCursorWasNull);
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
+    super(currentRowSupplier, setCursorWasNull, localCalendar);
     this.vector = vector;
   }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcLargeListVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcLargeListVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -31,8 +32,9 @@ public class ArrowFlightJdbcLargeListVectorAccessor
   public ArrowFlightJdbcLargeListVectorAccessor(
       LargeListVector vector,
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
-    super(currentRowSupplier, setCursorWasNull);
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
+    super(currentRowSupplier, setCursorWasNull, localCalendar);
     this.vector = vector;
   }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcListVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcListVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -31,8 +32,9 @@ public class ArrowFlightJdbcListVectorAccessor extends AbstractArrowFlightJdbcLi
   public ArrowFlightJdbcListVectorAccessor(
       ListVector vector,
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
-    super(currentRowSupplier, setCursorWasNull);
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
+    super(currentRowSupplier, setCursorWasNull, localCalendar);
     this.vector = vector;
   }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import java.util.Calendar;
 import java.util.Map;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -33,8 +34,9 @@ public class ArrowFlightJdbcMapVectorAccessor extends AbstractArrowFlightJdbcLis
   public ArrowFlightJdbcMapVectorAccessor(
       MapVector vector,
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
-    super(currentRowSupplier, setCursorWasNull);
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
+    super(currentRowSupplier, setCursorWasNull, localCalendar);
     this.vector = vector;
   }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessor.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import java.util.Calendar;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -37,15 +38,16 @@ public class ArrowFlightJdbcUnionVectorAccessor extends AbstractArrowFlightJdbcU
   public ArrowFlightJdbcUnionVectorAccessor(
       UnionVector vector,
       IntSupplier currentRowSupplier,
-      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
-    super(currentRowSupplier, setCursorWasNull);
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull,
+      Calendar localCalendar) {
+    super(currentRowSupplier, setCursorWasNull, localCalendar);
     this.vector = vector;
   }
 
   @Override
   protected ArrowFlightJdbcAccessor createAccessorForVector(ValueVector vector) {
     return ArrowFlightJdbcAccessorFactory.createAccessor(
-        vector, this::getCurrentRow, (boolean wasNull) -> {});
+        vector, this::getCurrentRow, (boolean wasNull) -> {}, localCalendar);
   }
 
   @Override

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArrayTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArrayTest.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashMap;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
 import org.apache.arrow.vector.IntVector;
@@ -58,21 +59,21 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetBaseTypeNameReturnCorrectTypeName() {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     assertEquals("INTEGER", arrowFlightJdbcArray.getBaseTypeName());
   }
 
   @Test
   public void testShouldGetBaseTypeReturnCorrectType() {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     assertEquals(Types.INTEGER, arrowFlightJdbcArray.getBaseType());
   }
 
   @Test
   public void testShouldGetArrayReturnValidArray() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     Object[] array = (Object[]) arrowFlightJdbcArray.getArray();
 
     Object[] expected = new Object[dataVector.getValueCount()];
@@ -85,7 +86,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetArrayReturnValidArrayWithOffsets() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     Object[] array = (Object[]) arrowFlightJdbcArray.getArray(1, 5);
 
     Object[] expected = new Object[5];
@@ -99,7 +100,7 @@ public class ArrowFlightJdbcArrayTest {
   public void testShouldGetArrayWithOffsetsThrowArrayIndexOutOfBoundsException()
       throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     assertThrows(
         ArrayIndexOutOfBoundsException.class,
         () -> arrowFlightJdbcArray.getArray(0, dataVector.getValueCount() + 1));
@@ -108,7 +109,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetArrayWithMapNotBeSupported() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     HashMap<String, Class<?>> map = new HashMap<>();
     assertThrows(SQLFeatureNotSupportedException.class, () -> arrowFlightJdbcArray.getArray(map));
   }
@@ -116,7 +117,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetArrayWithOffsetsAndMapNotBeSupported() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     HashMap<String, Class<?>> map = new HashMap<>();
     assertThrows(
         SQLFeatureNotSupportedException.class, () -> arrowFlightJdbcArray.getArray(0, 5, map));
@@ -125,7 +126,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetResultSetReturnValidResultSet() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     try (ResultSet resultSet = arrowFlightJdbcArray.getResultSet()) {
       int count = 0;
       while (resultSet.next()) {
@@ -138,7 +139,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetResultSetReturnValidResultSetWithOffsets() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     try (ResultSet resultSet = arrowFlightJdbcArray.getResultSet(3, 5)) {
       int count = 0;
       while (resultSet.next()) {
@@ -152,7 +153,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testToString() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
 
     JsonStringArrayList<Object> array = new JsonStringArrayList<>();
     array.addAll(Arrays.asList((Object[]) arrowFlightJdbcArray.getArray()));
@@ -163,7 +164,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetResultSetWithMapNotBeSupported() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     HashMap<String, Class<?>> map = new HashMap<>();
     assertThrows(
         SQLFeatureNotSupportedException.class, () -> arrowFlightJdbcArray.getResultSet(map));
@@ -172,7 +173,7 @@ public class ArrowFlightJdbcArrayTest {
   @Test
   public void testShouldGetResultSetWithOffsetsAndMapNotBeSupported() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
-        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());
+        new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount(), Calendar.getInstance());
     HashMap<String, Class<?>> map = new HashMap<>();
     assertThrows(
         SQLFeatureNotSupportedException.class, () -> arrowFlightJdbcArray.getResultSet(0, 5, map));

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/FlightServerTestExtension.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/FlightServerTestExtension.java
@@ -130,6 +130,12 @@ public class FlightServerTestExtension
     return this.createDataSource().getConnection();
   }
 
+  public Connection getConnection(String timezone) throws SQLException {
+    setUseEncryption(false);
+    properties.put("timezone", timezone);
+    return this.createDataSource().getConnection();
+  }
+
   private void setUseEncryption(boolean useEncryption) {
     properties.put("useEncryption", useEncryption);
   }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
@@ -87,10 +87,7 @@ public class TimestampResultSetTest {
                           if (v instanceof TimeStampMilliVector) {
                             ((TimeStampMilliVector) v).setSafe(0, firstDay2025.toEpochMilli());
                           } else if (v instanceof TimeStampMilliTZVector) {
-                            String vecTz =
-                                ((ArrowType.Timestamp) v.getField().getType()).getTimezone();
-                            long millis = firstDay2025.toEpochMilli();
-                            ((TimeStampMilliTZVector) v).setSafe(0, millis);
+                            ((TimeStampMilliTZVector) v).setSafe(0, firstDay2025.toEpochMilli());
                           }
                         });
                 root.setRowCount(1);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
@@ -65,8 +65,8 @@ public class TimestampResultSetTest {
           ImmutableList.of(
               Field.nullable("no_tz", new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)),
               Field.nullable("utc", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC")),
-              Field.nullable("utc+1", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT+1:00")),
-              Field.nullable("utc-1", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT-1:00"))));
+              Field.nullable("utc+1", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT+1")),
+              Field.nullable("utc-1", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT-1"))));
 
   @BeforeAll
   public static void setup() throws SQLException {

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
@@ -34,8 +34,7 @@ import java.util.TimeZone;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.TimeStampMilliTZVector;
-import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -82,14 +81,7 @@ public class TimestampResultSetTest {
                   final VectorSchemaRoot root = VectorSchemaRoot.create(QUERY_SCHEMA, allocator)) {
                 listener.start(root);
                 root.getFieldVectors()
-                    .forEach(
-                        v -> {
-                          if (v instanceof TimeStampMilliVector) {
-                            ((TimeStampMilliVector) v).setSafe(0, firstDay2025.toEpochMilli());
-                          } else if (v instanceof TimeStampMilliTZVector) {
-                            ((TimeStampMilliTZVector) v).setSafe(0, firstDay2025.toEpochMilli());
-                          }
-                        });
+                    .forEach(v -> ((TimeStampVector) v).setSafe(0, firstDay2025.toEpochMilli()));
                 root.setRowCount(1);
                 listener.putNext();
               } catch (final Throwable throwable) {

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TimestampResultSetTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.driver.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.TimeZone;
+import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Timestamps have a lot of nuances in JDBC. This class is here to test that timestamp behavior is
+ * correct for different types of Timestamp vectors as well as different methods of retrieving the
+ * timestamps in JDBC.
+ */
+public class TimestampResultSetTest {
+  private static final MockFlightSqlProducer FLIGHT_SQL_PRODUCER = new MockFlightSqlProducer();
+
+  @RegisterExtension public static FlightServerTestExtension FLIGHT_SERVER_TEST_EXTENSION;
+
+  static {
+    FLIGHT_SERVER_TEST_EXTENSION =
+        FlightServerTestExtension.createStandardTestExtension(FLIGHT_SQL_PRODUCER);
+  }
+
+  private static final String QUERY_STRING = "SELECT * FROM TIMESTAMPS";
+  private static final Schema QUERY_SCHEMA =
+      new Schema(
+          ImmutableList.of(
+              Field.nullable("no_tz", new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)),
+              Field.nullable("utc", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC")),
+              Field.nullable("utc+1", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT+1:00")),
+              Field.nullable("utc-1", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT-1:00"))));
+
+  @BeforeAll
+  public static void setup() throws SQLException {
+    Instant firstDay2025 = OffsetDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
+
+    FLIGHT_SQL_PRODUCER.addSelectQuery(
+        QUERY_STRING,
+        QUERY_SCHEMA,
+        Collections.singletonList(
+            listener -> {
+              try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                  final VectorSchemaRoot root = VectorSchemaRoot.create(QUERY_SCHEMA, allocator)) {
+                listener.start(root);
+                root.getFieldVectors()
+                    .forEach(
+                        v -> {
+                          if (v instanceof TimeStampMilliVector) {
+                            ((TimeStampMilliVector) v).setSafe(0, firstDay2025.toEpochMilli());
+                          } else if (v instanceof TimeStampMilliTZVector) {
+                            String vecTz =
+                                ((ArrowType.Timestamp) v.getField().getType()).getTimezone();
+                            long millis = firstDay2025.toEpochMilli();
+                            ((TimeStampMilliTZVector) v).setSafe(0, millis);
+                          }
+                        });
+                root.setRowCount(1);
+                listener.putNext();
+              } catch (final Throwable throwable) {
+                listener.error(throwable);
+              } finally {
+                listener.completed();
+              }
+            }));
+  }
+
+  /**
+   * This test doesn't yet test anything other than ensuring all ResultSet methods to retrieve a
+   * timestamp succeed.
+   *
+   * <p>This is a good starting point to add more tests to ensure the values are correct when we
+   * change the "local calendar" either through changing the JVM default or through the connection
+   * property.
+   */
+  @Test
+  public void test() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    try (Connection connection = FLIGHT_SERVER_TEST_EXTENSION.getConnection("UTC")) {
+      try (PreparedStatement s = connection.prepareStatement(QUERY_STRING)) {
+        try (ResultSet rs = s.executeQuery()) {
+          int numCols = rs.getMetaData().getColumnCount();
+          try {
+            rs.next();
+            for (int i = 1; i <= numCols; i++) {
+              int type = rs.getMetaData().getColumnType(i);
+              String name = rs.getMetaData().getColumnName(i);
+              System.out.println(name);
+              System.out.print("- getDate:\t\t\t\t\t\t\t");
+              System.out.print(rs.getDate(i));
+              System.out.println();
+              System.out.print("- getTimestamp:\t\t\t\t\t\t");
+              System.out.print(rs.getTimestamp(i));
+              System.out.println();
+              System.out.print("- getString:\t\t\t\t\t\t");
+              System.out.print(rs.getString(i));
+              System.out.println();
+              System.out.print("- getObject:\t\t\t\t\t\t");
+              System.out.print(rs.getObject(i));
+              System.out.println();
+              System.out.print("- getObject(Timestamp.class):\t\t");
+              System.out.print(rs.getObject(i, Timestamp.class));
+              System.out.println();
+              System.out.print("- getTimestamp(default Calendar):\t");
+              System.out.print(rs.getTimestamp(i, Calendar.getInstance()));
+              System.out.println();
+              System.out.print("- getTimestamp(UTC Calendar):\t\t");
+              System.out.print(
+                  rs.getTimestamp(i, Calendar.getInstance(TimeZone.getTimeZone("UTC"))));
+              System.out.println();
+              System.out.print("- getObject(LocalDateTime.class):\t");
+              System.out.print(rs.getObject(i, LocalDateTime.class));
+              System.out.println();
+              if (type == Types.TIMESTAMP_WITH_TIMEZONE) {
+                System.out.print("- getObject(Instant.class):\t\t\t");
+                System.out.print(rs.getObject(i, Instant.class));
+                System.out.println();
+                System.out.print("- getObject(OffsetDateTime.class):\t");
+                System.out.print(rs.getObject(i, OffsetDateTime.class));
+                System.out.println();
+                System.out.print("- getObject(ZonedDateTime.class):\t");
+                System.out.print(rs.getObject(i, ZonedDateTime.class));
+                System.out.println();
+              }
+              System.out.println();
+            }
+            System.out.println();
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactoryTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactoryTest.java
@@ -18,6 +18,7 @@ package org.apache.arrow.driver.jdbc.accessor;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Calendar;
 import java.util.function.IntSupplier;
 import org.apache.arrow.driver.jdbc.accessor.impl.binary.ArrowFlightJdbcBinaryVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorAccessor;
@@ -68,7 +69,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createUInt1Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -79,7 +80,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createUInt2Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -90,7 +91,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createUInt4Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -101,7 +102,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createUInt8Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -112,7 +113,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createTinyIntVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -123,7 +124,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createSmallIntVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -134,7 +135,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createIntVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -145,7 +146,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createBigIntVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -156,7 +157,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createFloat4Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcFloat4VectorAccessor);
     }
@@ -167,7 +168,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createFloat8Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcFloat8VectorAccessor);
     }
@@ -178,7 +179,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createBitVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBitVectorAccessor);
     }
@@ -189,7 +190,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createDecimalVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcDecimalVectorAccessor);
     }
@@ -200,7 +201,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createDecimal256Vector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcDecimalVectorAccessor);
     }
@@ -211,7 +212,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createVarBinaryVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBinaryVectorAccessor);
     }
@@ -222,7 +223,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createLargeVarBinaryVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBinaryVectorAccessor);
     }
@@ -233,7 +234,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createFixedSizeBinaryVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcBinaryVectorAccessor);
     }
@@ -244,7 +245,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createTimeStampMilliVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcTimeStampVectorAccessor);
     }
@@ -255,7 +256,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createTimeNanoVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -266,7 +267,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createTimeMicroVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -277,7 +278,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createTimeMilliVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -288,7 +289,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createTimeSecVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -299,7 +300,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createDateDayVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcDateVectorAccessor);
     }
@@ -310,7 +311,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createDateMilliVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcDateVectorAccessor);
     }
@@ -322,7 +323,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new VarCharVector("", rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcVarCharVectorAccessor);
     }
@@ -334,7 +335,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new LargeVarCharVector("", rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcVarCharVectorAccessor);
     }
@@ -349,7 +350,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
             rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcDurationVectorAccessor);
     }
@@ -361,7 +362,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new IntervalDayVector("", rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
     }
@@ -373,7 +374,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new IntervalYearVector("", rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
     }
@@ -385,7 +386,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new IntervalMonthDayNanoVector("", rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
     }
@@ -397,7 +398,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new UnionVector("", rootAllocatorTestExtension.getRootAllocator(), null, null)) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcUnionVectorAccessor);
     }
@@ -409,7 +410,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         new DenseUnionVector("", rootAllocatorTestExtension.getRootAllocator(), null, null)) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcDenseUnionVectorAccessor);
     }
@@ -421,7 +422,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         StructVector.empty("", rootAllocatorTestExtension.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcStructVectorAccessor);
     }
@@ -432,7 +433,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createListVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcListVectorAccessor);
     }
@@ -443,7 +444,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createLargeListVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcLargeListVectorAccessor);
     }
@@ -454,7 +455,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
     try (ValueVector valueVector = rootAllocatorTestExtension.createFixedSizeListVector()) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcFixedSizeListVectorAccessor);
     }
@@ -466,7 +467,7 @@ public class ArrowFlightJdbcAccessorFactoryTest {
         MapVector.empty("", rootAllocatorTestExtension.getRootAllocator(), true)) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(
-              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {}, Calendar.getInstance());
 
       assertTrue(accessor instanceof ArrowFlightJdbcMapVectorAccessor);
     }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -71,7 +71,10 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       accessorSupplier =
           (vector, getCurrentRow) ->
               new ArrowFlightJdbcTimeStampVectorAccessor(
-                  (TimeStampVector) vector, getCurrentRow, (boolean wasNull) -> {});
+                  (TimeStampVector) vector,
+                  getCurrentRow,
+                  (boolean wasNull) -> {},
+                  Calendar.getInstance());
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcTimeStampVectorAccessor>
       accessorIterator = new AccessorTestUtils.AccessorIterator<>(accessorSupplier);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListAccessorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -54,13 +55,19 @@ public class AbstractArrowFlightJdbcListAccessorTest {
                 (boolean wasNull) -> {};
             if (vector instanceof ListVector) {
               return new ArrowFlightJdbcListVectorAccessor(
-                  (ListVector) vector, getCurrentRow, noOpWasNullConsumer);
+                  (ListVector) vector, getCurrentRow, noOpWasNullConsumer, Calendar.getInstance());
             } else if (vector instanceof LargeListVector) {
               return new ArrowFlightJdbcLargeListVectorAccessor(
-                  (LargeListVector) vector, getCurrentRow, noOpWasNullConsumer);
+                  (LargeListVector) vector,
+                  getCurrentRow,
+                  noOpWasNullConsumer,
+                  Calendar.getInstance());
             } else if (vector instanceof FixedSizeListVector) {
               return new ArrowFlightJdbcFixedSizeListVectorAccessor(
-                  (FixedSizeListVector) vector, getCurrentRow, noOpWasNullConsumer);
+                  (FixedSizeListVector) vector,
+                  getCurrentRow,
+                  noOpWasNullConsumer,
+                  Calendar.getInstance());
             }
             return null;
           };

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessorTest.java
@@ -238,7 +238,7 @@ public class AbstractArrowFlightJdbcUnionVectorAccessorTest {
   private static class AbstractArrowFlightJdbcUnionVectorAccessorMock
       extends AbstractArrowFlightJdbcUnionVectorAccessor {
     protected AbstractArrowFlightJdbcUnionVectorAccessorMock() {
-      super(() -> 0, (boolean wasNull) -> {});
+      super(() -> 0, (boolean wasNull) -> {}, Calendar.getInstance());
     }
 
     @Override

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
@@ -52,7 +53,8 @@ public class ArrowFlightJdbcDenseUnionVectorAccessorTest {
                   getCurrentRow,
                   (boolean wasNull) -> {
                     // No Operation
-                  });
+                  },
+                  Calendar.getInstance());
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcDenseUnionVectorAccessor>
       accessorIterator = new AccessorTestUtils.AccessorIterator<>(accessorSupplier);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessorTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Calendar;
 import java.util.Map;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
@@ -105,7 +106,7 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
     AccessorTestUtils.Cursor cursor = new AccessorTestUtils.Cursor(vector.getValueCount());
     ArrowFlightJdbcMapVectorAccessor accessor =
         new ArrowFlightJdbcMapVectorAccessor(
-            vector, cursor::getCurrentRow, (boolean wasNull) -> {});
+            vector, cursor::getCurrentRow, (boolean wasNull) -> {}, Calendar.getInstance());
 
     Map<Object, Object> expected = new JsonStringHashMap<>();
     expected.put(1, 11);
@@ -134,7 +135,8 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
   public void testShouldGetObjectReturnNull() {
     vector.setNull(0);
     ArrowFlightJdbcMapVectorAccessor accessor =
-        new ArrowFlightJdbcMapVectorAccessor(vector, () -> 0, (boolean wasNull) -> {});
+        new ArrowFlightJdbcMapVectorAccessor(
+            vector, () -> 0, (boolean wasNull) -> {}, Calendar.getInstance());
 
     assertNull(accessor.getObject());
     assertTrue(accessor.wasNull());
@@ -145,7 +147,7 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
     AccessorTestUtils.Cursor cursor = new AccessorTestUtils.Cursor(vector.getValueCount());
     ArrowFlightJdbcMapVectorAccessor accessor =
         new ArrowFlightJdbcMapVectorAccessor(
-            vector, cursor::getCurrentRow, (boolean wasNull) -> {});
+            vector, cursor::getCurrentRow, (boolean wasNull) -> {}, Calendar.getInstance());
 
     Array array = accessor.getArray();
     assertNotNull(array);
@@ -210,7 +212,8 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
     ((StructVector) vector.getDataVector()).setNull(0);
 
     ArrowFlightJdbcMapVectorAccessor accessor =
-        new ArrowFlightJdbcMapVectorAccessor(vector, () -> 0, (boolean wasNull) -> {});
+        new ArrowFlightJdbcMapVectorAccessor(
+            vector, () -> 0, (boolean wasNull) -> {}, Calendar.getInstance());
 
     assertNull(accessor.getArray());
     assertTrue(accessor.wasNull());

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
@@ -47,7 +48,10 @@ public class ArrowFlightJdbcUnionVectorAccessorTest {
       accessorSupplier =
           (vector, getCurrentRow) ->
               new ArrowFlightJdbcUnionVectorAccessor(
-                  (UnionVector) vector, getCurrentRow, (boolean wasNull) -> {});
+                  (UnionVector) vector,
+                  getCurrentRow,
+                  (boolean wasNull) -> {},
+                  Calendar.getInstance());
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcUnionVectorAccessor>
       accessorIterator = new AccessorTestUtils.AccessorIterator<>(accessorSupplier);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -652,7 +652,7 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
         rootAllocatorTestExtension.createTimeStampMilliVector()) {
       ArrowFlightJdbcTimeStampVectorAccessor timeStampVectorAccessor =
           new ArrowFlightJdbcTimeStampVectorAccessor(
-              timeStampVector, () -> 0, (boolean wasNull) -> {});
+              timeStampVector, () -> 0, (boolean wasNull) -> {}, Calendar.getInstance());
 
       Text value = new Text(timeStampVectorAccessor.getString());
       when(getter.get(0)).thenReturn(value.copyBytes());


### PR DESCRIPTION
## What's Changed

The Avatica driver takes a `timezone` property, which can be used to override the default system timezone. Currently, not all methods of fetching values from accessors respect this value.

This PR ensures the local timezone gets set on the `ArrowFlightJdbcTimeStampVectorAccessor` and makes sure we respect that over the default JVM timezone.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->



Closes #NNN.
