### PR TITLE
GH-592: [Release] Use relative path in .sha*

### DIFF
--- a/ci/scripts/jni_full_build.sh
+++ b/ci/scripts/jni_full_build.sh
@@ -97,8 +97,10 @@ find ~/.m2/repository/org/apache/arrow \
   -exec echo "{}" ";" \
   -exec cp "{}" "${dist_dir}" ";"
 
-for artifact in "${dist_dir}"/*; do
+pushd "${dist_dir}"
+for artifact in *; do
   sha256sum "${artifact}" >"${artifact}.sha256"
   sha512sum "${artifact}" >"${artifact}.sha512"
 done
+popd
 github_actions_group_end


### PR DESCRIPTION
## What's Changed

If we use absolute path, users need to create the same directory structure. It's inconvenient. We should use relative path.

Closes #592.
