### PR TITLE
GH-900: Fix gandiva groupId in arrow-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -165,7 +165,7 @@ under the License.
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.arrow</groupId>
+        <groupId>org.apache.arrow.gandiva</groupId>
         <artifactId>arrow-gandiva</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Use correct groupId for the `arrow-gandiva` artifact.

Closes #900.