### PR TITLE
GH-926: Shade arrow-compression with Flight JDBC driver

### DIFF
--- a/flight/flight-sql-jdbc-core/pom.xml
+++ b/flight/flight-sql-jdbc-core/pom.xml
@@ -80,6 +80,11 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-compression</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/flight/flight-sql-jdbc-core/pom.xml
+++ b/flight/flight-sql-jdbc-core/pom.xml
@@ -82,6 +82,7 @@ under the License.
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-compression</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/flight/flight-sql-jdbc-driver/pom.xml
+++ b/flight/flight-sql-jdbc-driver/pom.xml
@@ -101,6 +101,8 @@ under the License.
                   <shadedPattern>org.apache.arrow.driver.jdbc.shaded.com.</shadedPattern>
                   <excludes>
                     <exclude>com.sun.**</exclude>
+                    <!-- zstd-jni uses JNI native methods bound to original class names -->
+                    <exclude>com.github.luben.**</exclude>
                   </excludes>
                 </relocation>
                 <relocation>

--- a/flight/flight-sql-jdbc-driver/src/shade/LICENSE.txt
+++ b/flight/flight-sql-jdbc-driver/src/shade/LICENSE.txt
@@ -373,3 +373,43 @@ License text:
 | NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 | DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
 | OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains zstd-jni 1.5.7-6.
+
+Copyright: Copyright (c) 2015-present, Luben Karavelov
+Home page: https://github.com/luben/zstd-jni
+License: BSD 2-Clause License
+License text:
+
+| Copyright (c) 2015-present, Luben Karavelov. All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without modification,
+| are permitted provided that the following conditions are met:
+|
+| * Redistributions of source code must retain the above copyright notice, this
+|   list of conditions and the following disclaimer.
+|
+| * Redistributions in binary form must reproduce the above copyright notice, this
+|   list of conditions and the following disclaimer in the documentation and/or
+|   other materials provided with the distribution.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+| ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+| WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+| ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+| (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+| LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+| ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This binary artifact contains Apache Commons Compress 1.27.1.
+
+Copyright: Copyright 2002-2024 The Apache Software Foundation
+Home page: https://commons.apache.org/proper/commons-compress/
+License: https://www.apache.org/licenses/LICENSE-2.0

--- a/flight/flight-sql-jdbc-driver/src/shade/NOTICE.txt
+++ b/flight/flight-sql-jdbc-driver/src/shade/NOTICE.txt
@@ -338,3 +338,34 @@ This product includes Netty 4.1.119.Final, with the following in its NOTICE:
 |     * license/LICENSE.brotli4j.txt (Apache License 2.0)
 |   * HOMEPAGE:
 |     * https://github.com/hyperxpro/Brotli4j
+
+---------------------------------------------------
+
+This product includes zstd-jni 1.5.7-6, with the following in its NOTICE:
+
+| zstd-jni - JNI bindings for Zstd
+| =================================
+|
+| Copyright (c) 2015-present, Luben Karavelov. All rights reserved.
+|
+| This product provides JNI bindings for the Zstd compression library.
+|
+|   * LICENSE:
+|     * BSD 2-Clause License
+|   * HOMEPAGE:
+|     * https://github.com/luben/zstd-jni
+
+---------------------------------------------------
+
+This product includes Apache Commons Compress 1.27.1, with the following in its NOTICE:
+
+| Apache Commons Compress
+| Copyright 2002-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
+|
+|   * LICENSE:
+|     * Apache License 2.0
+|   * HOMEPAGE:
+|     * https://commons.apache.org/proper/commons-compress/

--- a/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ITDriverJarValidation.java
+++ b/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ITDriverJarValidation.java
@@ -56,6 +56,13 @@ public class ITDriverJarValidation {
   public static final Set<String> ALLOWED_PREFIXES =
       ImmutableSet.of(
           "org/apache/arrow/driver/jdbc/", // Driver code
+          // zstd-jni classes and native libraries must keep their original names
+          "com/github/luben/zstd/",
+          "aix/",
+          "darwin/",
+          "freebsd/",
+          "linux/",
+          "win/",
           "META-INF/maven/", // Maven metadata (useful for security scanner
           "META-INF/services/", // ServiceLoader implementations
           "META-INF/license/",


### PR DESCRIPTION
## What's Changed

Flight JDBC driver does not support IPC compressed formats. This PR includes and shades arrow-compression when packing JDBC driver.
For zstd compression, it is excluding zstd-jni relocation since it needs JNI native methods to keep original location.

Closes #926.

This PR was assisted by AI