### PR TITLE
GH-942: Fix JDBC Connection.setCatalog()

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightMetaImpl.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightMetaImpl.java
@@ -79,7 +79,8 @@ public class ArrowFlightMetaImpl extends MetaImpl {
   public void closeStatement(final StatementHandle statementHandle) {
     PreparedStatement preparedStatement =
         statementHandlePreparedStatementMap.remove(new StatementHandleKey(statementHandle));
-    // Testing if the prepared statement was created because the statement can be not created until
+    // Testing if the prepared statement was created because the statement can be
+    // not created until
     // this moment
     if (preparedStatement != null) {
       preparedStatement.close();
@@ -224,7 +225,8 @@ public class ArrowFlightMetaImpl extends MetaImpl {
           MetaResultSet.create(handle.connectionId, handle.id, false, handle.signature, null);
       return new ExecuteResult(Collections.singletonList(metaResultSet));
     } catch (SQLTimeoutException e) {
-      // So far AvaticaStatement(executeInternal) only handles NoSuchStatement and Runtime
+      // So far AvaticaStatement(executeInternal) only handles NoSuchStatement and
+      // Runtime
       // Exceptions.
       throw new RuntimeException(e);
     } catch (SQLException e) {
@@ -253,6 +255,20 @@ public class ArrowFlightMetaImpl extends MetaImpl {
     return false;
   }
 
+  @Override
+  public ConnectionProperties connectionSync(ConnectionHandle ch, ConnectionProperties connProps) {
+    final ConnectionProperties result = super.connectionSync(ch, connProps);
+    final String newCatalog = this.connProps.getCatalog();
+    if (newCatalog != null) {
+      try {
+        ((ArrowFlightConnection) connection).getClientHandler().setCatalog(newCatalog);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return result;
+  }
+
   void setDefaultConnectionProperties() {
     // TODO Double-check this.
     connProps
@@ -268,7 +284,8 @@ public class ArrowFlightMetaImpl extends MetaImpl {
     return statementHandlePreparedStatementMap.get(new StatementHandleKey(statementHandle));
   }
 
-  // Helper used to look up prepared statement instances later. Avatica doesn't give us the
+  // Helper used to look up prepared statement instances later. Avatica doesn't
+  // give us the
   // signature in
   // an UPDATE code path so we can't directly use StatementHandle as a map key.
   private static final class StatementHandleKey {

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -47,20 +47,20 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Tests for {@link Connection}. */
 public class ConnectionTest {
 
-  @RegisterExtension
-  public static final FlightServerTestExtension FLIGHT_SERVER_TEST_EXTENSION;
+  @RegisterExtension public static final FlightServerTestExtension FLIGHT_SERVER_TEST_EXTENSION;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
   private static final String userTest = "user1";
   private static final String passTest = "pass1";
 
   static {
-    UserPasswordAuthentication authentication = new UserPasswordAuthentication.Builder().user(userTest, passTest)
-        .build();
+    UserPasswordAuthentication authentication =
+        new UserPasswordAuthentication.Builder().user(userTest, passTest).build();
 
-    FLIGHT_SERVER_TEST_EXTENSION = new FlightServerTestExtension.Builder()
-        .authentication(authentication)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_EXTENSION =
+        new FlightServerTestExtension.Builder()
+            .authentication(authentication)
+            .producer(PRODUCER)
+            .build();
   }
 
   private BufferAllocator allocator;
@@ -77,8 +77,7 @@ public class ConnectionTest {
   }
 
   /**
-   * Checks if an unencrypted connection can be established successfully when the
-   * provided valid
+   * Checks if an unencrypted connection can be established successfully when the provided valid
    * credentials.
    *
    * @throws SQLException on error.
@@ -95,19 +94,19 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        "jdbc:arrow-flight-sql://"
-            + FLIGHT_SERVER_TEST_EXTENSION.getHost()
-            + ":"
-            + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            "jdbc:arrow-flight-sql://"
+                + FLIGHT_SERVER_TEST_EXTENSION.getHost()
+                + ":"
+                + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
+            properties)) {
       assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Checks if a token is provided it takes precedence over username/pass. In this
-   * case, the
+   * Checks if a token is provided it takes precedence over username/pass. In this case, the
    * connection should fail if a token is passed in.
    */
   @Test
@@ -122,24 +121,25 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.TOKEN.camelName(), "token");
     properties.put("useEncryption", false);
 
-    SQLException e = assertThrows(
-        SQLException.class,
-        () -> {
-          try (Connection conn = DriverManager.getConnection(
-              "jdbc:arrow-flight-sql://"
-                  + FLIGHT_SERVER_TEST_EXTENSION.getHost()
-                  + ":"
-                  + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
-              properties)) {
-            fail();
-          }
-        });
+    SQLException e =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              try (Connection conn =
+                  DriverManager.getConnection(
+                      "jdbc:arrow-flight-sql://"
+                          + FLIGHT_SERVER_TEST_EXTENSION.getHost()
+                          + ":"
+                          + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
+                      properties)) {
+                fail();
+              }
+            });
     assertTrue(e.getMessage().contains("UNAUTHENTICATED"));
   }
 
   /**
-   * Checks if the exception SQLException is thrown when trying to establish a
-   * connection without a
+   * Checks if the exception SQLException is thrown when trying to establish a connection without a
    * host.
    *
    * @throws SQLException on error.
@@ -169,22 +169,22 @@ public class ConnectionTest {
   @Test
   public void testGetBasicClientAuthenticatedShouldOpenConnection() throws Exception {
 
-    try (ArrowFlightSqlClientHandler client = new ArrowFlightSqlClientHandler.Builder()
-        .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
-        .withPort(FLIGHT_SERVER_TEST_EXTENSION.getPort())
-        .withEncryption(false)
-        .withUsername(userTest)
-        .withPassword(passTest)
-        .withBufferAllocator(allocator)
-        .build()) {
+    try (ArrowFlightSqlClientHandler client =
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
+            .withPort(FLIGHT_SERVER_TEST_EXTENSION.getPort())
+            .withEncryption(false)
+            .withUsername(userTest)
+            .withPassword(passTest)
+            .withBufferAllocator(allocator)
+            .build()) {
 
       assertNotNull(client);
     }
   }
 
   /**
-   * Checks if the exception IllegalArgumentException is thrown when trying to
-   * establish an
+   * Checks if the exception IllegalArgumentException is thrown when trying to establish an
    * unencrypted connection providing with an invalid port.
    *
    * @throws SQLException on error.
@@ -197,7 +197,8 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
-    final String invalidUrl = "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_EXTENSION.getHost() + ":" + 65537;
+    final String invalidUrl =
+        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_EXTENSION.getHost() + ":" + 65537;
 
     assertThrows(
         SQLException.class,
@@ -216,18 +217,18 @@ public class ConnectionTest {
   @Test
   public void testGetBasicClientNoAuthShouldOpenConnection() throws Exception {
 
-    try (ArrowFlightSqlClientHandler client = new ArrowFlightSqlClientHandler.Builder()
-        .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
-        .withBufferAllocator(allocator)
-        .withEncryption(false)
-        .build()) {
+    try (ArrowFlightSqlClientHandler client =
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
+            .withBufferAllocator(allocator)
+            .withEncryption(false)
+            .build()) {
       assertNotNull(client);
     }
   }
 
   /**
-   * Checks if an unencrypted connection can be established successfully when not
-   * providing
+   * Checks if an unencrypted connection can be established successfully when not providing
    * credentials.
    *
    * @throws SQLException on error.
@@ -240,14 +241,14 @@ public class ConnectionTest {
     properties.put(
         ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_EXTENSION.getPort());
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
-    try (Connection connection = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
+    try (Connection connection =
+        DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
       assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Check if an unencrypted connection throws an exception when provided with
-   * invalid credentials.
+   * Check if an unencrypted connection throws an exception when provided with invalid credentials.
    *
    * @throws SQLException The exception expected to be thrown.
    */
@@ -267,16 +268,15 @@ public class ConnectionTest {
     assertThrows(
         SQLException.class,
         () -> {
-          try (
-              Connection ignored = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
+          try (Connection ignored =
+              DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
             fail();
           }
         });
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
+   * Check if an non-encrypted connection can be established successfully when connecting through
    * the DriverManager using just a connection url.
    *
    * @throws Exception on error.
@@ -286,25 +286,25 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=false",
-            FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=false",
+                FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest))) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with String K-V
-   * pairs.
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with String K-V pairs.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyFalseCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyFalseCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -314,19 +314,18 @@ public class ConnectionTest {
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "false");
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with Object K-V
-   * pairs.
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with Object K-V pairs.
    *
    * @throws Exception on error.
    */
@@ -341,19 +340,18 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using just a connection url and using 0 and 1 as ssl
-   * values.
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using just a connection url and using 0 and 1 as ssl values.
    *
    * @throws Exception on error.
    */
@@ -363,26 +361,26 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=0",
-            FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=0",
+                FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest))) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with String K-V pairs
-   * and using 0 and 1
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with String K-V pairs and using 0 and 1
    * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
     Properties properties = new Properties();
@@ -391,26 +389,26 @@ public class ConnectionTest {
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "0");
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with Object K-V pairs
-   * and using 0 and 1
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1
    * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -419,17 +417,17 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), 0);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
+   * Check if an non-encrypted connection can be established successfully when connecting through
    * the DriverManager using just a connection url.
    *
    * @throws Exception on error.
@@ -440,26 +438,26 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&threadPoolSize=1&useEncryption=%s",
-            FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest, false))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&threadPoolSize=1&useEncryption=%s",
+                FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest, false))) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with String K-V pairs
-   * and using 0 and 1
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with String K-V pairs and using 0 and 1
    * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
     Properties properties = new Properties();
@@ -469,26 +467,26 @@ public class ConnectionTest {
     properties.setProperty(ArrowFlightConnectionProperty.THREAD_POOL_SIZE.camelName(), "1");
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with Object K-V pairs
-   * and using 0 and 1
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1
    * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -498,17 +496,17 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.THREAD_POOL_SIZE.camelName(), 1);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
+   * Check if an non-encrypted connection can be established successfully when connecting through
    * the DriverManager using just a connection url.
    *
    * @throws Exception on error.
@@ -519,26 +517,26 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=%s",
-            FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest, false))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=%s",
+                FLIGHT_SERVER_TEST_EXTENSION.getPort(), userTest, passTest, false))) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with String K-V pairs
-   * and using 0 and 1
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with String K-V pairs and using 0 and 1
    * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
     Properties properties = new Properties();
@@ -547,26 +545,26 @@ public class ConnectionTest {
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an non-encrypted connection can be established successfully when
-   * connecting through
-   * the DriverManager using a connection url and properties with Object K-V pairs
-   * and using 0 and 1
+   * Check if an non-encrypted connection can be established successfully when connecting through
+   * the DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1
    * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -575,17 +573,17 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_EXTENSION.getPort()),
+            properties)) {
       assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Test that the JDBC driver properly integrates driver version into client
-   * handler.
+   * Test that the JDBC driver properly integrates driver version into client handler.
    *
    * @throws Exception on error.
    */
@@ -603,20 +601,23 @@ public class ConnectionTest {
     // Create a driver instance and connect
     ArrowFlightJdbcDriver driverVersion = new ArrowFlightJdbcDriver();
 
-    try (Connection connection = ArrowFlightConnection.createNewConnection(
-        driverVersion,
-        new ArrowFlightJdbcFactory(),
-        "jdbc:arrow-flight-sql://localhost:" + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
-        properties,
-        allocator)) {
+    try (Connection connection =
+        ArrowFlightConnection.createNewConnection(
+            driverVersion,
+            new ArrowFlightJdbcFactory(),
+            "jdbc:arrow-flight-sql://localhost:" + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
+            properties,
+            allocator)) {
 
       assertTrue(connection.isValid(0));
 
-      var actualUserAgent = FLIGHT_SERVER_TEST_EXTENSION
-          .getInterceptorFactory()
-          .getHeader(FlightMethod.HANDSHAKE, "user-agent");
+      var actualUserAgent =
+          FLIGHT_SERVER_TEST_EXTENSION
+              .getInterceptorFactory()
+              .getHeader(FlightMethod.HANDSHAKE, "user-agent");
 
-      var expectedUserAgent = "JDBC Flight SQL Driver " + driverVersion.getDriverVersion().versionString;
+      var expectedUserAgent =
+          "JDBC Flight SQL Driver " + driverVersion.getDriverVersion().versionString;
       // Driver appends version to grpc user-agent header. Assert the header starts
       // with the
       // expected
@@ -634,26 +635,28 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        "jdbc:arrow-flight-sql://"
-            + FLIGHT_SERVER_TEST_EXTENSION.getHost()
-            + ":"
-            + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            "jdbc:arrow-flight-sql://"
+                + FLIGHT_SERVER_TEST_EXTENSION.getHost()
+                + ":"
+                + FLIGHT_SERVER_TEST_EXTENSION.getPort(),
+            properties)) {
       final String catalog = "new_catalog";
       connection.setCatalog(catalog);
 
       final Map<String, SessionOptionValue> options = PRODUCER.getSessionOptions();
       assertTrue(options.containsKey("catalog"));
-      String actualCatalog = options
-          .get("catalog")
-          .acceptVisitor(
-              new NoOpSessionOptionValueVisitor<String>() {
-                @Override
-                public String visit(String value) {
-                  return value;
-                }
-              });
+      String actualCatalog =
+          options
+              .get("catalog")
+              .acceptVisitor(
+                  new NoOpSessionOptionValueVisitor<String>() {
+                    @Override
+                    public String visit(String value) {
+                      return value;
+                    }
+                  });
       assertEquals(catalog, actualCatalog);
     }
   }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
@@ -94,8 +94,10 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   private final Map<String, Entry<Schema, List<UUID>>> queryResults = new HashMap<>();
   private final Map<UUID, Consumer<ServerStreamListener>> selectResultProviders = new HashMap<>();
   private final Map<ByteString, String> preparedStatements = new HashMap<>();
-  private final Map<Message, Consumer<ServerStreamListener>> catalogQueriesResults = new HashMap<>();
-  private final Map<String, BiConsumer<FlightStream, StreamListener<PutResult>>> updateResultProviders = new HashMap<>();
+  private final Map<Message, Consumer<ServerStreamListener>> catalogQueriesResults =
+      new HashMap<>();
+  private final Map<String, BiConsumer<FlightStream, StreamListener<PutResult>>>
+      updateResultProviders = new HashMap<>();
   private final SqlInfoBuilder sqlInfoBuilder = new SqlInfoBuilder();
   private final Map<String, Schema> parameterSchemas = new HashMap<>();
   private final Map<String, List<List<Object>>> expectedParameterValues = new HashMap<>();
@@ -131,8 +133,8 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   /**
    * Registers a new {@link StatementType#SELECT} SQL query.
    *
-   * @param sqlCommand      the SQL command under which to register the new query.
-   * @param schema          the schema to use for the query result.
+   * @param sqlCommand the SQL command under which to register the new query.
+   * @param schema the schema to use for the query result.
    * @param resultProviders the result provider for this query.
    */
   public void addSelectQuery(
@@ -140,9 +142,10 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final Schema schema,
       final List<Consumer<ServerStreamListener>> resultProviders) {
     final int providers = resultProviders.size();
-    final List<UUID> uuids = IntStream.range(0, providers)
-        .mapToObj(index -> new UUID(sqlCommand.hashCode(), Integer.hashCode(index)))
-        .collect(toList());
+    final List<UUID> uuids =
+        IntStream.range(0, providers)
+            .mapToObj(index -> new UUID(sqlCommand.hashCode(), Integer.hashCode(index)))
+            .collect(toList());
     queryResults.put(sqlCommand, new SimpleImmutableEntry<>(schema, uuids));
     IntStream.range(0, providers)
         .forEach(
@@ -152,14 +155,15 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   /**
    * Registers a new {@link StatementType#UPDATE} SQL query.
    *
-   * @param sqlCommand  the SQL command.
+   * @param sqlCommand the SQL command.
    * @param updatedRows the number of rows affected.
    */
   public void addUpdateQuery(final String sqlCommand, final long updatedRows) {
     addUpdateQuery(
         sqlCommand,
         (flightStream, putResultStreamListener) -> {
-          final DoPutUpdateResult result = DoPutUpdateResult.newBuilder().setRecordCount(updatedRows).build();
+          final DoPutUpdateResult result =
+              DoPutUpdateResult.newBuilder().setRecordCount(updatedRows).build();
           try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
               final ArrowBuf buffer = allocator.buffer(result.getSerializedSize())) {
             buffer.writeBytes(result.toByteArray());
@@ -175,8 +179,7 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   /**
    * Adds a catalog query to the results.
    *
-   * @param message         the {@link Message} corresponding to the catalog query
-   *                        request type to register.
+   * @param message the {@link Message} corresponding to the catalog query request type to register.
    * @param resultsProvider the results provider.
    */
   public void addCatalogQuery(
@@ -187,7 +190,7 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   /**
    * Registers a new {@link StatementType#UPDATE} SQL query.
    *
-   * @param sqlCommand      the SQL command.
+   * @param sqlCommand the SQL command.
    * @param resultsProvider consumer for producing update results.
    */
   void addUpdateQuery(
@@ -211,11 +214,13 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final CallContext callContext,
       final StreamListener<Result> listener) {
     try {
-      final ByteString preparedStatementHandle = copyFrom(randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+      final ByteString preparedStatementHandle =
+          copyFrom(randomUUID().toString().getBytes(StandardCharsets.UTF_8));
       final String query = request.getQuery();
 
-      final ActionCreatePreparedStatementResult.Builder resultBuilder = ActionCreatePreparedStatementResult.newBuilder()
-          .setPreparedStatementHandle(preparedStatementHandle);
+      final ActionCreatePreparedStatementResult.Builder resultBuilder =
+          ActionCreatePreparedStatementResult.newBuilder()
+              .setPreparedStatementHandle(preparedStatementHandle);
 
       final Entry<Schema, List<UUID>> entry = queryResults.get(query);
       if (entry != null) {
@@ -265,13 +270,15 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final CallContext callContext,
       final FlightDescriptor flightDescriptor) {
     final String query = commandStatementQuery.getQuery();
-    final Entry<Schema, List<UUID>> queryInfo = Preconditions.checkNotNull(
-        queryResults.get(query), format("Query not registered: <%s>.", query));
-    final List<FlightEndpoint> endpoints = queryInfo.getValue().stream()
-        .map(TicketConversionUtils::getTicketBytesFromUuid)
-        .map(TicketConversionUtils::getTicketStatementQueryFromHandle)
-        .map(TicketConversionUtils::getEndpointFromMessage)
-        .collect(toList());
+    final Entry<Schema, List<UUID>> queryInfo =
+        Preconditions.checkNotNull(
+            queryResults.get(query), format("Query not registered: <%s>.", query));
+    final List<FlightEndpoint> endpoints =
+        queryInfo.getValue().stream()
+            .map(TicketConversionUtils::getTicketBytesFromUuid)
+            .map(TicketConversionUtils::getTicketStatementQueryFromHandle)
+            .map(TicketConversionUtils::getEndpointFromMessage)
+            .collect(toList());
     return FlightInfo.builder(queryInfo.getKey(), flightDescriptor, endpoints)
         .setAppMetadata("foo".getBytes(StandardCharsets.UTF_8))
         .build();
@@ -282,18 +289,22 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final CommandPreparedStatementQuery commandPreparedStatementQuery,
       final CallContext callContext,
       final FlightDescriptor flightDescriptor) {
-    final ByteString preparedStatementHandle = commandPreparedStatementQuery.getPreparedStatementHandle();
+    final ByteString preparedStatementHandle =
+        commandPreparedStatementQuery.getPreparedStatementHandle();
 
-    final String query = Preconditions.checkNotNull(
-        preparedStatements.get(preparedStatementHandle),
-        format("No query registered under handle: <%s>.", preparedStatementHandle));
-    final Entry<Schema, List<UUID>> queryInfo = Preconditions.checkNotNull(
-        queryResults.get(query), format("Query not registered: <%s>.", query));
-    final List<FlightEndpoint> endpoints = queryInfo.getValue().stream()
-        .map(TicketConversionUtils::getTicketBytesFromUuid)
-        .map(TicketConversionUtils::getCommandPreparedStatementQueryFromHandle)
-        .map(TicketConversionUtils::getEndpointFromMessage)
-        .collect(toList());
+    final String query =
+        Preconditions.checkNotNull(
+            preparedStatements.get(preparedStatementHandle),
+            format("No query registered under handle: <%s>.", preparedStatementHandle));
+    final Entry<Schema, List<UUID>> queryInfo =
+        Preconditions.checkNotNull(
+            queryResults.get(query), format("Query not registered: <%s>.", query));
+    final List<FlightEndpoint> endpoints =
+        queryInfo.getValue().stream()
+            .map(TicketConversionUtils::getTicketBytesFromUuid)
+            .map(TicketConversionUtils::getCommandPreparedStatementQueryFromHandle)
+            .map(TicketConversionUtils::getEndpointFromMessage)
+            .collect(toList());
     return FlightInfo.builder(queryInfo.getKey(), flightDescriptor, endpoints)
         .setAppMetadata("foo".getBytes(StandardCharsets.UTF_8))
         .build();
@@ -305,8 +316,9 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final CallContext callContext,
       final FlightDescriptor flightDescriptor) {
     final String query = commandStatementQuery.getQuery();
-    final Entry<Schema, List<UUID>> queryInfo = Preconditions.checkNotNull(
-        queryResults.get(query), format("Query not registered: <%s>.", query));
+    final Entry<Schema, List<UUID>> queryInfo =
+        Preconditions.checkNotNull(
+            queryResults.get(query), format("Query not registered: <%s>.", query));
 
     return new SchemaResult(queryInfo.getKey());
   }
@@ -318,9 +330,9 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final ServerStreamListener serverStreamListener) {
     final UUID uuid = UUID.fromString(ticketStatementQuery.getStatementHandle().toStringUtf8());
     Preconditions.checkNotNull(
-        selectResultProviders.get(uuid),
-        "No consumer was registered for the specified UUID: <%s>.",
-        uuid)
+            selectResultProviders.get(uuid),
+            "No consumer was registered for the specified UUID: <%s>.",
+            uuid)
         .accept(serverStreamListener);
   }
 
@@ -329,11 +341,12 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final CommandPreparedStatementQuery commandPreparedStatementQuery,
       final CallContext callContext,
       final ServerStreamListener serverStreamListener) {
-    final UUID uuid = UUID.fromString(commandPreparedStatementQuery.getPreparedStatementHandle().toStringUtf8());
+    final UUID uuid =
+        UUID.fromString(commandPreparedStatementQuery.getPreparedStatementHandle().toStringUtf8());
     Preconditions.checkNotNull(
-        selectResultProviders.get(uuid),
-        "No consumer was registered for the specified UUID: <%s>.",
-        uuid)
+            selectResultProviders.get(uuid),
+            "No consumer was registered for the specified UUID: <%s>.",
+            uuid)
         .accept(serverStreamListener);
   }
 
@@ -345,9 +358,10 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final StreamListener<PutResult> streamListener) {
     return () -> {
       final String query = commandStatementUpdate.getQuery();
-      final BiConsumer<FlightStream, StreamListener<PutResult>> resultProvider = Preconditions.checkNotNull(
-          updateResultProviders.get(query),
-          format("No consumer found for query: <%s>.", query));
+      final BiConsumer<FlightStream, StreamListener<PutResult>> resultProvider =
+          Preconditions.checkNotNull(
+              updateResultProviders.get(query),
+              format("No consumer found for query: <%s>.", query));
       resultProvider.accept(flightStream, streamListener);
     };
   }
@@ -381,7 +395,8 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
             Object actual = root.getVector(paramIndex).getObject(i);
             boolean matches;
             if (expected.getClass().isArray()) {
-              matches = Arrays.equals((Object[]) expected, ((JsonStringArrayList) actual).toArray());
+              matches =
+                  Arrays.equals((Object[]) expected, ((JsonStringArrayList) actual).toArray());
             } else {
               matches = Objects.equals(expected, actual);
             }
@@ -415,13 +430,13 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final FlightStream flightStream,
       final StreamListener<PutResult> streamListener) {
     final ByteString handle = commandPreparedStatementUpdate.getPreparedStatementHandle();
-    final String query = Preconditions.checkNotNull(
-        preparedStatements.get(handle),
-        format("No query registered under handle: <%s>.", handle));
+    final String query =
+        Preconditions.checkNotNull(
+            preparedStatements.get(handle),
+            format("No query registered under handle: <%s>.", handle));
 
     if (validateParameters(query, flightStream, streamListener)) {
-      return () -> {
-      };
+      return () -> {};
     }
 
     return acceptPutStatement(
@@ -438,13 +453,13 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       final FlightStream flightStream,
       final StreamListener<PutResult> streamListener) {
     final ByteString handle = commandPreparedStatementQuery.getPreparedStatementHandle();
-    final String query = Preconditions.checkNotNull(
-        preparedStatements.get(handle),
-        format("No query registered under handle: <%s>.", handle));
+    final String query =
+        Preconditions.checkNotNull(
+            preparedStatements.get(handle),
+            format("No query registered under handle: <%s>.", handle));
 
     if (validateParameters(query, flightStream, streamListener)) {
-      return () -> {
-      };
+      return () -> {};
     }
 
     return streamListener::onCompleted;
@@ -629,8 +644,7 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   }
 
   /**
-   * Clear the `actionTypeCounter` map and restore to its default state. Intended
-   * to be used in
+   * Clear the `actionTypeCounter` map and restore to its default state. Intended to be used in
    * tests.
    */
   public void clearActionTypeCounter() {
@@ -644,8 +658,8 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   private void getStreamCatalogFunctions(
       final Message ticket, final ServerStreamListener serverStreamListener) {
     Preconditions.checkNotNull(
-        catalogQueriesResults.get(ticket),
-        format("Query not registered for ticket: <%s>", ticket))
+            catalogQueriesResults.get(ticket),
+            format("Query not registered for ticket: <%s>", ticket))
         .accept(serverStreamListener);
   }
 


### PR DESCRIPTION
## What's Changed

Connection.setCatalog() is not silently ignored anymore (through the default implementation in Calcite) but instead it updates the catalog session option in the same way as during the initial connection.

Closes #942.
