### PR TITLE
GH-993: Fix missing pipe in milestone assignment script

### DIFF
--- a/.github/workflows/dev_pr_milestone.sh
+++ b/.github/workflows/dev_pr_milestone.sh
@@ -37,8 +37,8 @@ main() {
     local -r milestone=$(
       gh api "/repos/${repo}/milestones" |
         jq --raw-output '.[] | .title' |
-        grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'
-      head -n1
+        grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' |
+        head -n1
     )
 
     echo "Assigning milestone: ${milestone}"


### PR DESCRIPTION
The `head -n1` command was not piped to grep output, causing all matching milestones to be captured instead of just the first one.

Example failure:
```
  Assigning milestone: 19.0.0
  20.0.0
  '19.0.0
  20.0.0' not found
```

Closes #993