### PR TITLE
fix: does not break class loading if direct buffer allocator is not available

### DIFF
--- a/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -18,6 +18,7 @@ package org.apache.arrow.memory.util;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -107,6 +108,9 @@ public class MemoryUtil {
                       logger.debug("Cannot get constructor for direct buffer allocation", e);
                       return e;
                     } catch (SecurityException e) {
+                      logger.debug("Cannot get constructor for direct buffer allocation", e);
+                      return e;
+                    } catch (InaccessibleObjectException e) {
                       logger.debug("Cannot get constructor for direct buffer allocation", e);
                       return e;
                     }


### PR DESCRIPTION
## What's Changed

The Direct Buffer is not always needed to use Arrow memory, however, we cannot load MemoryUtil class if we don't set:
```
--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
```
Which is not always needed/possible.

This fix proposes to catch the `InaccessibleObjectException` to not avoiding the load of the class.

The directBuffer is, in any case not available and a `UnsupportedOperationException` will be throw as it is in the existing code 



Closes #1007 .
