### PR TITLE
MINOR: [Docs] Remove extra line in README.md (fix pre-commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,3 @@ the profile:
 ```bash
 mvn -Pintegration-tests <rest of mvn arguments>
 ```
-


### PR DESCRIPTION
## What's Changed

Remove extra line in README.md for fixing the `end-of-file-fixer` hook in the `pre-commit` build.

E.g. [here](https://github.com/apache/arrow-java/actions/runs/21902454512/job/63233962122) in the main branch build.
```
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing README.md
```

