### PR TITLE
GH-1021: Use released apache/arrow instead of main

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -107,18 +107,12 @@ jobs:
       - name: Extract source archive
         run: |
           tar -xf apache-arrow-java-*.tar.gz --strip-components=1
-      # We always use the main branch for apache/arrow for now.
-      # Because we want to use
-      # https://github.com/apache/arrow/pull/45114 in
-      # apache/arrow-java. We can revert this workaround once Apache
-      # Arrow 20.0.0 that includes the change released.
-      #
-      # - name: Download the latest Apache Arrow C++
-      #   if: github.event_name != 'schedule'
-      #   run: |
-      #     ci/scripts/download_cpp.sh
+      - name: Download the latest Apache Arrow C++
+        if: github.event_name != 'schedule'
+        run: |
+          ci/scripts/download_cpp.sh
       - name: Checkout Apache Arrow C++
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         uses: actions/checkout@v6
         with:
           repository: apache/arrow
@@ -180,12 +174,12 @@ jobs:
       - name: Extract source archive
         run: |
           tar -xf apache-arrow-java-*.tar.gz --strip-components=1
-      # - name: Download the latest Apache Arrow C++
-      #   if: github.event_name != 'schedule'
-      #   run: |
-      #     ci/scripts/download_cpp.sh
+      - name: Download the latest Apache Arrow C++
+        if: github.event_name != 'schedule'
+        run: |
+          ci/scripts/download_cpp.sh
       - name: Checkout Apache Arrow C++
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         uses: actions/checkout@v6
         with:
           repository: apache/arrow
@@ -309,19 +303,13 @@ jobs:
         shell: bash
         run: |
           tar -xf apache-arrow-java-*.tar.gz --strip-components=1
-      # We always use the main branch for apache/arrow for now.
-      # Because we want to use
-      # https://github.com/apache/arrow/pull/47749 in
-      # apache/arrow-java. We can revert this workaround once Apache
-      # Arrow 22.0.0 that includes the change released.
-      #
-      # - name: Download the latest Apache Arrow C++
-      #   if: github.event_name != 'schedule'
-      #   shell: bash
-      #   run: |
-      #     ci/scripts/download_cpp.sh
+      - name: Download the latest Apache Arrow C++
+        if: github.event_name != 'schedule'
+        shell: bash
+        run: |
+          ci/scripts/download_cpp.sh
       - name: Checkout Apache Arrow C++
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         uses: actions/checkout@v6
         with:
           repository: apache/arrow


### PR DESCRIPTION
## What's Changed

In general, we should use released apache/arrow for apache/arrow-java release.

Closes #1021.
