### PR TITLE
GH-1020: Update vcpkg revision

### DIFF
--- a/.env
+++ b/.env
@@ -53,4 +53,4 @@ MAVEN=3.9.9
 # Versions for various dependencies used to build artifacts
 # Keep in sync with apache/arrow
 ARROW_REPO_ROOT=./arrow
-VCPKG="4334d8b4c8916018600212ab4dd4bbdc343065d1"    # 2025.09.17 Release
+VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -77,7 +77,7 @@ jobs:
           path: |
             apache-arrow-java-*
   jni-linux:
-    name: JNI ${{ matrix.platform.runs_on }} ${{ matrix.platform.arch }}
+    name: JNI ${{ matrix.platform.runs_on }} ${{ matrix.platform.arch }} (C++ ${{ matrix.apache-arrow-cpp }})
     runs-on: ${{ matrix.platform.runs_on }}
     timeout-minutes: 120
     needs:
@@ -92,6 +92,9 @@ jobs:
           - runs_on: ubuntu-24.04-arm
             arch: "aarch_64"
             archery_arch: "arm64v8"
+        apache-arrow-cpp:
+          - main
+          - released
     env:
       # architecture name used for archery build
       ARCH: ${{ matrix.platform.archery_arch }}
@@ -108,11 +111,11 @@ jobs:
         run: |
           tar -xf apache-arrow-java-*.tar.gz --strip-components=1
       - name: Download the latest Apache Arrow C++
-        if: github.event_name != 'schedule'
+        if: matrix.apache-arrow-cpp == 'released'
         run: |
           ci/scripts/download_cpp.sh
       - name: Checkout Apache Arrow C++
-        if: github.event_name == 'schedule'
+        if: matrix.apache-arrow-cpp == 'main'
         uses: actions/checkout@v6
         with:
           repository: apache/arrow

--- a/compose.yaml
+++ b/compose.yaml
@@ -108,6 +108,7 @@ services:
     environment:
       ARROW_JAVA_CDATA: "ON"
       CCACHE_DIR: "/ccache"
-    command:
-      ["git config --global --add safe.directory /arrow-java && \
-        /arrow-java/ci/scripts/jni_manylinux_build.sh /arrow-java /arrow /build/java /arrow-java/jni"]
+    command: >-
+      /bin/bash -c "
+        git config --global --add safe.directory /arrow-java &&
+        /arrow-java/ci/scripts/jni_manylinux_build.sh /arrow-java /arrow /build/java /arrow-java/jni"


### PR DESCRIPTION
## What's Changed

apache/arrow updated vcpkg revision by https://github.com/apache/arrow/pull/49062 . It's not released yet but we use apache/arrow main in our nightly CI jobs that are failed. So we should follow the change as soon as possible.

Closes #1020.
