### PR TITLE
MINOR: Fix flaky TestBasicAuth memory leak by waiting for async buffer release

### DIFF
--- a/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
+++ b/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
@@ -178,6 +178,12 @@ public class TestBasicAuth {
     AutoCloseables.close(server);
 
     allocator.getChildAllocators().forEach(BufferAllocator::close);
+
+    // gRPC/Netty may still be releasing Arrow buffers asynchronously after server shutdown.
+    // Poll briefly to allow in-flight buffer releases to complete before closing the allocator.
+    for (int i = 0; i < 20 && allocator.getAllocatedMemory() > 0; i++) {
+      Thread.sleep(100);
+    }
     AutoCloseables.close(allocator);
   }
 }


### PR DESCRIPTION
## What's Changed

gRPC/Netty releases Arrow buffers asynchronously after server shutdown. Poll briefly for the allocator's memory to drain before closing it, preventing spurious "Memory was leaked" errors in CI.

The fix adds a brief polling loop to wait for the allocator's memory to drain before closing it.
