### PR TITLE
MINOR: [CI] Increase JNI macOS job timeout from 45 to 60 minutes

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -155,7 +155,7 @@ jobs:
   jni-macos:
     name: JNI ${{ matrix.platform.runs_on }} ${{ matrix.platform.arch }}
     runs-on: ${{ matrix.platform.runs_on }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     needs:
       - source
     strategy:


### PR DESCRIPTION
As MacOS executor as slightly slower than other executors, this PR increase the JNI MacOS job timeout to 60 minutes (instead of 45 minutes).