### PR TITLE
GH-838: [FlightSQL][JDBC] Fix timestamp unit conversion and sub-millisecond precision in PreparedStatement parameter binding

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightMetaImpl.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightMetaImpl.java
@@ -19,6 +19,7 @@ package org.apache.arrow.driver.jdbc;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaParameter;
+import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.MetaImpl;
 import org.apache.calcite.avatica.NoSuchStatementException;
@@ -105,9 +107,10 @@ public class ArrowFlightMetaImpl extends MetaImpl {
       throw new IllegalStateException("Prepared statement not found: " + statementHandle);
     }
 
+    Map<Integer, Timestamp> rawTimestamps = getRawTimestamps(statementHandle);
     new AvaticaParameterBinder(
             preparedStatement, ((ArrowFlightConnection) connection).getBufferAllocator())
-        .bind(typedValues);
+        .bind(typedValues, 0, rawTimestamps);
 
     if (statementHandle.signature == null
         || statementHandle.signature.statementType == StatementType.IS_DML) {
@@ -149,11 +152,12 @@ public class ArrowFlightMetaImpl extends MetaImpl {
       throw new IllegalStateException("Prepared statement not found: " + statementHandle);
     }
 
+    Map<Integer, Timestamp> rawTimestamps = getRawTimestamps(statementHandle);
     final AvaticaParameterBinder binder =
         new AvaticaParameterBinder(
             preparedStatement, ((ArrowFlightConnection) connection).getBufferAllocator());
     for (int i = 0; i < parameterValuesList.size(); i++) {
-      binder.bind(parameterValuesList.get(i), i);
+      binder.bind(parameterValuesList.get(i), i, rawTimestamps);
     }
 
     // Update query
@@ -171,6 +175,14 @@ public class ArrowFlightMetaImpl extends MetaImpl {
      */
     throw AvaticaConnection.HELPER.wrap(
         String.format("%s does not use frames.", this), AvaticaConnection.HELPER.unsupported());
+  }
+
+  private Map<Integer, Timestamp> getRawTimestamps(StatementHandle statementHandle) {
+    AvaticaStatement avaticaStmt = connection.statementMap.get(statementHandle.id);
+    if (avaticaStmt instanceof ArrowFlightPreparedStatement) {
+      return ((ArrowFlightPreparedStatement) avaticaStmt).getRawTimestamps();
+    }
+    return Collections.emptyMap();
   }
 
   private PreparedStatement prepareForHandle(final String query, StatementHandle handle) {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
@@ -83,7 +83,7 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
   @Override
   public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
     if (x != null) {
-      rawTimestamps.put(parameterIndex, x);
+      rawTimestamps.put(parameterIndex, (Timestamp) x.clone());
     } else {
       rawTimestamps.remove(parameterIndex);
     }
@@ -93,11 +93,30 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
   @Override
   public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
     if (x != null) {
-      rawTimestamps.put(parameterIndex, x);
+      rawTimestamps.put(parameterIndex, (Timestamp) x.clone());
     } else {
       rawTimestamps.remove(parameterIndex);
     }
     super.setTimestamp(parameterIndex, x, cal);
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    rawTimestamps.remove(parameterIndex);
+    super.setObject(parameterIndex, x, targetSqlType);
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x) throws SQLException {
+    rawTimestamps.remove(parameterIndex);
+    super.setObject(parameterIndex, x);
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    rawTimestamps.remove(parameterIndex);
+    super.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
   }
 
   @Override

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
@@ -18,6 +18,11 @@ package org.apache.arrow.driver.jdbc;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.util.Preconditions;
@@ -30,6 +35,7 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
     implements ArrowFlightInfoStatement {
 
   private final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement;
+  private final Map<Integer, Timestamp> rawTimestamps = new HashMap<>();
 
   private ArrowFlightPreparedStatement(
       final ArrowFlightConnection connection,
@@ -72,6 +78,41 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
   public synchronized void close() throws SQLException {
     this.preparedStatement.close();
     super.close();
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    if (x != null) {
+      rawTimestamps.put(parameterIndex, x);
+    } else {
+      rawTimestamps.remove(parameterIndex);
+    }
+    super.setTimestamp(parameterIndex, x);
+  }
+
+  @Override
+  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+    if (x != null) {
+      rawTimestamps.put(parameterIndex, x);
+    } else {
+      rawTimestamps.remove(parameterIndex);
+    }
+    super.setTimestamp(parameterIndex, x, cal);
+  }
+
+  @Override
+  public void clearParameters() throws SQLException {
+    rawTimestamps.clear();
+    super.clearParameters();
+  }
+
+  /**
+   * Returns the raw java.sql.Timestamp objects set via setTimestamp(), keyed by 1-based parameter
+   * index. These preserve sub-millisecond precision (getNanos()) that Avatica's TypedValue
+   * serialization discards.
+   */
+  Map<Integer, Timestamp> getRawTimestamps() {
+    return Collections.unmodifiableMap(rawTimestamps);
   }
 
   @Override

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FixedSizeListAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FixedSizeListAvaticaParameterConverter.java
@@ -66,7 +66,10 @@ public class FixedSizeListAvaticaParameterConverter extends BaseAvaticaParameter
               .getType()
               .accept(
                   new AvaticaParameterBinder.BinderVisitor(
-                      childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
+                      childVector,
+                      TypedValue.ofSerial(typedValue.componentType, val),
+                      childIndex,
+                      null));
         }
       }
       listVector.setValueCount(index + 1);

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeListAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeListAvaticaParameterConverter.java
@@ -55,7 +55,10 @@ public class LargeListAvaticaParameterConverter extends BaseAvaticaParameterConv
               .getType()
               .accept(
                   new AvaticaParameterBinder.BinderVisitor(
-                      childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
+                      childVector,
+                      TypedValue.ofSerial(typedValue.componentType, val),
+                      childIndex,
+                      null));
         }
       }
       listVector.endValue(index, values.size());

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/ListAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/ListAvaticaParameterConverter.java
@@ -54,7 +54,10 @@ public class ListAvaticaParameterConverter extends BaseAvaticaParameterConverter
               .getType()
               .accept(
                   new AvaticaParameterBinder.BinderVisitor(
-                      childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
+                      childVector,
+                      TypedValue.ofSerial(typedValue.componentType, val),
+                      childIndex,
+                      null));
         }
       }
       listVector.endValue(index, values.size());

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
@@ -33,11 +33,31 @@ import org.apache.calcite.avatica.remote.TypedValue;
 /** AvaticaParameterConverter for Timestamp Arrow types. */
 public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public TimestampAvaticaParameterConverter(ArrowType.Timestamp type) {}
+  private final ArrowType.Timestamp type;
+
+  public TimestampAvaticaParameterConverter(ArrowType.Timestamp type) {
+    this.type = type;
+  }
+
+  /** Converts an epoch millisecond value from Avatica to the target time unit. */
+  private long convertFromMillis(long epochMillis) {
+    switch (type.getUnit()) {
+      case SECOND:
+        return epochMillis / 1_000L;
+      case MILLISECOND:
+        return epochMillis;
+      case MICROSECOND:
+        return epochMillis * 1_000L;
+      case NANOSECOND:
+        return epochMillis * 1_000_000L;
+      default:
+        throw new UnsupportedOperationException("Unsupported time unit: " + type.getUnit());
+    }
+  }
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
-    long value = (long) typedValue.toLocal();
+    long value = convertFromMillis((long) typedValue.toLocal());
     if (vector instanceof TimeStampSecVector) {
       ((TimeStampSecVector) vector).setSafe(index, value);
       return true;

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.TimeStampSecVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
+import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.remote.TypedValue;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -93,7 +94,8 @@ public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConv
   public boolean bindParameter(
       FieldVector vector, TypedValue typedValue, int index, @Nullable Timestamp rawTimestamp) {
     long value;
-    if (rawTimestamp != null) {
+    // Only use the raw timestamp if the TypedValue actually represents a timestamp.
+    if (rawTimestamp != null && typedValue.type == ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP) {
       value = convertFromTimestamp(rawTimestamp);
     } else {
       value = convertFromMillis((long) typedValue.toLocal());

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
@@ -17,7 +17,6 @@
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import java.sql.Timestamp;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
@@ -31,6 +30,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** AvaticaParameterConverter for Timestamp Arrow types. */
 public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConverter {
@@ -69,7 +69,7 @@ public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConv
   private long convertFromMillis(long epochMillis) {
     switch (type.getUnit()) {
       case SECOND:
-        return epochMillis / 1_000L;
+        return Math.floorDiv(epochMillis, 1_000L);
       case MILLISECOND:
         return epochMillis;
       case MICROSECOND:

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.arrow.driver.jdbc.converter.impl;
 
+import java.sql.Timestamp;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
@@ -39,6 +41,30 @@ public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConv
     this.type = type;
   }
 
+  /**
+   * Converts a raw java.sql.Timestamp to the value in the target Arrow time unit, preserving
+   * sub-millisecond precision from Timestamp.getNanos().
+   */
+  private long convertFromTimestamp(Timestamp ts) {
+    // Timestamp.getTime() returns epoch millis (truncated, no sub-ms precision).
+    // Timestamp.getNanos() returns the fractional-second component in nanoseconds (0..999_999_999).
+    // We reconstruct the full-precision value from epoch seconds + nanos to avoid double-counting.
+    long epochSeconds = Math.floorDiv(ts.getTime(), 1_000L);
+    int nanos = ts.getNanos(); // 0..999_999_999, full fractional second
+    switch (type.getUnit()) {
+      case SECOND:
+        return epochSeconds;
+      case MILLISECOND:
+        return epochSeconds * 1_000L + nanos / 1_000_000;
+      case MICROSECOND:
+        return epochSeconds * 1_000_000L + nanos / 1_000;
+      case NANOSECOND:
+        return epochSeconds * 1_000_000_000L + nanos;
+      default:
+        throw new UnsupportedOperationException("Unsupported time unit: " + type.getUnit());
+    }
+  }
+
   /** Converts an epoch millisecond value from Avatica to the target time unit. */
   private long convertFromMillis(long epochMillis) {
     switch (type.getUnit()) {
@@ -55,9 +81,33 @@ public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConv
     }
   }
 
+  /**
+   * Bind a timestamp parameter, using the raw java.sql.Timestamp if available for full precision.
+   *
+   * @param vector FieldVector to bind to.
+   * @param typedValue TypedValue from Avatica (epoch millis, may have lost sub-ms precision).
+   * @param index Vector index to bind the value at.
+   * @param rawTimestamp Optional raw java.sql.Timestamp preserving sub-millisecond nanos.
+   * @return true if binding was successful.
+   */
+  public boolean bindParameter(
+      FieldVector vector, TypedValue typedValue, int index, @Nullable Timestamp rawTimestamp) {
+    long value;
+    if (rawTimestamp != null) {
+      value = convertFromTimestamp(rawTimestamp);
+    } else {
+      value = convertFromMillis((long) typedValue.toLocal());
+    }
+    return setTimestampVector(vector, index, value);
+  }
+
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
     long value = convertFromMillis((long) typedValue.toLocal());
+    return setTimestampVector(vector, index, value);
+  }
+
+  private boolean setTimestampVector(FieldVector vector, int index, long value) {
     if (vector instanceof TimeStampSecVector) {
       ((TimeStampSecVector) vector).setSafe(index, value);
       return true;

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java
@@ -16,7 +16,10 @@
  */
 package org.apache.arrow.driver.jdbc.utils;
 
+import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler.PreparedStatement;
 import org.apache.arrow.driver.jdbc.converter.impl.BinaryAvaticaParameterConverter;
 import org.apache.arrow.driver.jdbc.converter.impl.BinaryViewAvaticaParameterConverter;
@@ -81,7 +84,7 @@ public class AvaticaParameterBinder {
    * @param typedValues The parameter values.
    */
   public void bind(List<TypedValue> typedValues) {
-    bind(typedValues, 0);
+    bind(typedValues, 0, Collections.emptyMap());
   }
 
   /**
@@ -91,6 +94,19 @@ public class AvaticaParameterBinder {
    * @param index index for parameter.
    */
   public void bind(List<TypedValue> typedValues, int index) {
+    bind(typedValues, index, Collections.emptyMap());
+  }
+
+  /**
+   * Bind the given Avatica values to the prepared statement at the given index, with optional raw
+   * java.sql.Timestamp values that preserve sub-millisecond precision.
+   *
+   * @param typedValues The parameter values.
+   * @param index index for parameter.
+   * @param rawTimestamps Raw java.sql.Timestamp objects keyed by 1-based parameter index.
+   */
+  public void bind(
+      List<TypedValue> typedValues, int index, Map<Integer, Timestamp> rawTimestamps) {
     if (preparedStatement.getParameterSchema().getFields().size() != typedValues.size()) {
       throw new IllegalStateException(
           String.format(
@@ -99,7 +115,9 @@ public class AvaticaParameterBinder {
     }
 
     for (int i = 0; i < typedValues.size(); i++) {
-      bind(parameters.getVector(i), typedValues.get(i), index);
+      // rawTimestamps uses 1-based JDBC parameter indices
+      Timestamp rawTs = rawTimestamps.get(i + 1);
+      bind(parameters.getVector(i), typedValues.get(i), index, rawTs);
     }
 
     if (!typedValues.isEmpty()) {
@@ -114,8 +132,13 @@ public class AvaticaParameterBinder {
    * @param vector FieldVector to bind to.
    * @param typedValue TypedValue to bind to the vector.
    * @param index Vector index to bind the value at.
+   * @param rawTimestamp Optional raw java.sql.Timestamp with sub-millisecond precision.
    */
-  private void bind(FieldVector vector, @Nullable TypedValue typedValue, int index) {
+  private void bind(
+      FieldVector vector,
+      @Nullable TypedValue typedValue,
+      int index,
+      @Nullable Timestamp rawTimestamp) {
     try {
       if (typedValue == null || typedValue.value == null) {
         if (vector.getField().isNullable()) {
@@ -126,7 +149,7 @@ public class AvaticaParameterBinder {
       } else if (!vector
           .getField()
           .getType()
-          .accept(new BinderVisitor(vector, typedValue, index))) {
+          .accept(new BinderVisitor(vector, typedValue, index, rawTimestamp))) {
         throw new UnsupportedOperationException(
             String.format("Binding to vector type %s is not yet supported", vector.getClass()));
       }
@@ -146,6 +169,7 @@ public class AvaticaParameterBinder {
     private final FieldVector vector;
     private final TypedValue typedValue;
     private final int index;
+    @Nullable private final Timestamp rawTimestamp;
 
     /**
      * Instantiate a new BinderVisitor.
@@ -153,11 +177,14 @@ public class AvaticaParameterBinder {
      * @param vector FieldVector to bind values to.
      * @param value TypedValue to bind.
      * @param index Vector index (0-based) to bind the value to.
+     * @param rawTimestamp Optional raw java.sql.Timestamp preserving sub-millisecond precision.
      */
-    public BinderVisitor(FieldVector vector, TypedValue value, int index) {
+    public BinderVisitor(
+        FieldVector vector, TypedValue value, int index, @Nullable Timestamp rawTimestamp) {
       this.vector = vector;
       this.typedValue = value;
       this.index = index;
+      this.rawTimestamp = rawTimestamp;
     }
 
     @Override
@@ -266,7 +293,8 @@ public class AvaticaParameterBinder {
 
     @Override
     public Boolean visit(ArrowType.Timestamp type) {
-      return new TimestampAvaticaParameterConverter(type).bindParameter(vector, typedValue, index);
+      return new TimestampAvaticaParameterConverter(type)
+          .bindParameter(vector, typedValue, index, rawTimestamp);
     }
 
     @Override

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java
@@ -105,8 +105,7 @@ public class AvaticaParameterBinder {
    * @param index index for parameter.
    * @param rawTimestamps Raw java.sql.Timestamp objects keyed by 1-based parameter index.
    */
-  public void bind(
-      List<TypedValue> typedValues, int index, Map<Integer, Timestamp> rawTimestamps) {
+  public void bind(List<TypedValue> typedValues, int index, Map<Integer, Timestamp> rawTimestamps) {
     if (preparedStatement.getParameterSchema().getFields().size() != typedValues.size()) {
       throw new IllegalStateException(
           String.format(

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
@@ -28,6 +28,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +39,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -249,6 +251,57 @@ public class ArrowFlightPreparedStatementTest {
       stmt.addBatch();
       int[] updated = stmt.executeBatch();
       assertEquals(42, updated[0]);
+    }
+  }
+
+  @Test
+  public void testTimestampParameterWithMicrosecondPrecision() throws SQLException {
+    String query = "Fake timestamp micro update";
+    // Server schema declares parameter as TIMESTAMP(MICROSECOND, UTC)
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))));
+
+    // TimeStampMicroTZVector.getObject() returns Long (raw epoch micros)
+    // epochSeconds=1730637909, nanos=869885001 → micros = 1730637909 * 1_000_000 + 869885
+    List<List<Object>> expected =
+        Collections.singletonList(Collections.singletonList(1730637909869885L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      Timestamp ts = new Timestamp(1730637909869L);
+      ts.setNanos(869885001); // .869885001 seconds — sub-ms precision
+      stmt.setTimestamp(1, ts);
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
+    }
+  }
+
+  @Test
+  public void testTimestampParameterWithMillisecondPrecision() throws SQLException {
+    String query = "Fake timestamp milli update";
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"))));
+
+    // TimeStampMilliTZVector.getObject() returns Long (raw epoch millis)
+    // Sub-ms nanos are correctly truncated for MILLISECOND target
+    List<List<Object>> expected =
+        Collections.singletonList(Collections.singletonList(1730637909869L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      Timestamp ts = new Timestamp(1730637909869L);
+      ts.setNanos(869885001);
+      stmt.setTimestamp(1, ts);
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
     }
   }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
@@ -389,6 +389,33 @@ public class ArrowFlightPreparedStatementTest {
   }
 
   @Test
+  public void testSetLongAfterSetTimestampIgnoresRawTimestamp() throws SQLException {
+    String query = "Fake timestamp setLong after setTimestamp";
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))));
+
+    // setLong replaces the timestamp TypedValue with millis. The stale raw timestamp must be
+    // ignored, so the long value 1000L becomes 1000000 epoch micros.
+    List<List<Object>> expected = Collections.singletonList(Collections.singletonList(1000000L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      Timestamp ts = new Timestamp(1730637909869L);
+      ts.setNanos(869885001);
+      stmt.setTimestamp(1, ts);
+
+      stmt.setLong(1, 1000L);
+
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
+    }
+  }
+
+  @Test
   public void testSetTimestampAfterSetObjectPreservesSubMillis() throws SQLException {
     String query = "Fake timestamp setTimestamp after setObject";
     Schema parameterSchema =

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
@@ -304,4 +304,117 @@ public class ArrowFlightPreparedStatementTest {
       assertEquals(1, updated);
     }
   }
+
+  @Test
+  public void testTimestampMutationAfterSetDoesNotAffectBoundValue() throws SQLException {
+    String query = "Fake timestamp mutation test";
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))));
+
+    // Original: epochSeconds=1730637909, nanos=869885001 → micros = 1730637909869885
+    List<List<Object>> expected =
+        Collections.singletonList(Collections.singletonList(1730637909869885L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      Timestamp ts = new Timestamp(1730637909869L);
+      ts.setNanos(869885001);
+      stmt.setTimestamp(1, ts);
+
+      // Mutate the Timestamp after setTimestamp — should not affect the stored value
+      ts.setNanos(0);
+      ts.setTime(0);
+
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
+    }
+  }
+
+  @Test
+  public void testTimestampSetObjectFallsBackToMillis() throws SQLException {
+    String query = "Fake timestamp setObject test";
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))));
+
+    // setObject goes through Avatica's millis-only path: 1730637909869 * 1000 = 1730637909869000
+    List<List<Object>> expected =
+        Collections.singletonList(Collections.singletonList(1730637909869000L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      Timestamp ts = new Timestamp(1730637909869L);
+      ts.setNanos(869885001); // sub-ms nanos present but will be lost via setObject
+      stmt.setObject(1, ts);
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
+    }
+  }
+
+  @Test
+  public void testSetObjectAfterSetTimestampClearsRawTimestamp() throws SQLException {
+    String query = "Fake timestamp setObject after setTimestamp";
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))));
+
+    // After setObject replaces setTimestamp, millis-only path is used:
+    // 1000L (epoch millis) * 1000 = 1000000 (epoch micros)
+    List<List<Object>> expected = Collections.singletonList(Collections.singletonList(1000000L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      // First set with setTimestamp (populates rawTimestamps)
+      Timestamp ts1 = new Timestamp(1730637909869L);
+      ts1.setNanos(869885001);
+      stmt.setTimestamp(1, ts1);
+
+      // Then replace with setObject (should clear rawTimestamps for this index)
+      Timestamp ts2 = new Timestamp(1000L);
+      stmt.setObject(1, ts2);
+
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
+    }
+  }
+
+  @Test
+  public void testSetTimestampAfterSetObjectPreservesSubMillis() throws SQLException {
+    String query = "Fake timestamp setTimestamp after setObject";
+    Schema parameterSchema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))));
+
+    // setTimestamp called last, so rawTimestamp is used: epochSeconds=1730637909, nanos=869885001
+    List<List<Object>> expected =
+        Collections.singletonList(Collections.singletonList(1730637909869885L));
+
+    PRODUCER.addUpdateQuery(query, 1);
+    PRODUCER.addExpectedParameters(query, parameterSchema, expected);
+
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      // First set with setObject (millis only)
+      Timestamp ts1 = new Timestamp(1000L);
+      stmt.setObject(1, ts1);
+
+      // Then replace with setTimestamp (populates rawTimestamps with sub-ms precision)
+      Timestamp ts2 = new Timestamp(1730637909869L);
+      ts2.setNanos(869885001);
+      stmt.setTimestamp(1, ts2);
+
+      int updated = stmt.executeUpdate();
+      assertEquals(1, updated);
+    }
+  }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.driver.jdbc.converter.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecTZVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.calcite.avatica.ColumnMetaData;
+import org.apache.calcite.avatica.remote.TypedValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link TimestampAvaticaParameterConverter}. */
+public class TimestampAvaticaParameterConverterTest {
+
+  @RegisterExtension
+  public static RootAllocatorTestExtension rootAllocatorTestExtension =
+      new RootAllocatorTestExtension();
+
+  // A known epoch millis value: 2024-11-03 12:45:09.869 UTC
+  private static final long EPOCH_MILLIS = 1730637909869L;
+
+  @Test
+  public void testBindParameterMilliVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampMilliVector vector = new TimeStampMilliVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      assertEquals(EPOCH_MILLIS, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testBindParameterMicroVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampMicroVector vector = new TimeStampMicroVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      // Millis should be converted to micros
+      assertEquals(EPOCH_MILLIS * 1_000L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testBindParameterNanoVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.NANOSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampNanoVector vector = new TimeStampNanoVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      // Millis should be converted to nanos
+      assertEquals(EPOCH_MILLIS * 1_000_000L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testBindParameterSecVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampSecVector vector = new TimeStampSecVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      // Millis should be converted to seconds
+      assertEquals(EPOCH_MILLIS / 1_000L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testBindParameterMicroTZVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC");
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampMicroTZVector vector = new TimeStampMicroTZVector("ts", allocator, "UTC")) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      assertEquals(EPOCH_MILLIS * 1_000L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testBindParameterNanoTZVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC");
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampNanoTZVector vector = new TimeStampNanoTZVector("ts", allocator, "UTC")) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      assertEquals(EPOCH_MILLIS * 1_000_000L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testBindParameterSecTZVector() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, "UTC");
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampSecTZVector vector = new TimeStampSecTZVector("ts", allocator, "UTC")) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      assertEquals(EPOCH_MILLIS / 1_000L, vector.get(0));
+    }
+  }
+}

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
@@ -152,4 +152,20 @@ public class TimestampAvaticaParameterConverterTest {
       assertEquals(EPOCH_MILLIS / 1_000L, vector.get(0));
     }
   }
+
+  @Test
+  public void testBindParameterSecVectorTruncatesSubSecond() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampSecVector vector = new TimeStampSecVector("ts", allocator)) {
+      vector.allocateNew(1);
+      // 1999 millis should truncate to 1 second, not round to 2
+      long millis = 1999L;
+      TypedValue typedValue = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, millis);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      assertEquals(1L, vector.get(0));
+    }
+  }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
@@ -19,6 +19,7 @@ package org.apache.arrow.driver.jdbc.converter.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.sql.Timestamp;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.BaseFixedWidthVector;
@@ -87,6 +88,102 @@ public class TimestampAvaticaParameterConverterTest {
   public void testNanoTZVector() {
     assertBindConvertsMillis(
         TimeUnit.NANOSECOND, "UTC", TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS * 1_000_000L);
+  }
+
+  @Test
+  public void testMicroVectorPreservesSubMillisecondPrecision() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    // Issue #838 exact values: 2024-11-03 12:45:09.869885001
+    Timestamp ts = new Timestamp(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+    ts.setNanos(869885001); // .869885001 seconds — sub-ms precision
+
+    try (TimeStampMicroVector vector = new TimeStampMicroVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(
+              ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0, ts));
+      // epochSeconds=1730637909, nanos=869885001 → micros = 1730637909 * 1_000_000 + 869885
+      assertEquals(1730637909869885L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testNanoVectorPreservesFullNanosecondPrecision() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.NANOSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    Timestamp ts = new Timestamp(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+    ts.setNanos(869885001);
+
+    try (TimeStampNanoVector vector = new TimeStampNanoVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(
+              ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0, ts));
+      // epochSeconds=1730637909, nanos=869885001 → nanos = 1730637909 * 1_000_000_000 + 869885001
+      assertEquals(1730637909869885001L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testMilliVectorFromRawTimestampTruncatesSubMillisecond() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    Timestamp ts = new Timestamp(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+    ts.setNanos(869885001); // sub-ms nanos are truncated for MILLISECOND target
+
+    try (TimeStampMilliVector vector = new TimeStampMilliVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(
+              ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0, ts));
+      assertEquals(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testSecVectorFromRawTimestampTruncatesSubSecond() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    Timestamp ts = new Timestamp(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+    ts.setNanos(869885001);
+
+    try (TimeStampSecVector vector = new TimeStampSecVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(
+              ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0, ts));
+      assertEquals(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS / 1_000L, vector.get(0));
+    }
+  }
+
+  @Test
+  public void testFallbackToMillisWhenRawTimestampIsNull() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampMicroVector vector = new TimeStampMicroVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(
+              ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+      // null rawTimestamp → falls back to convertFromMillis
+      assertTrue(converter.bindParameter(vector, typedValue, 0, null));
+      assertEquals(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS * 1_000L, vector.get(0));
+    }
   }
 
   @Test

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
@@ -246,6 +246,30 @@ public class TimestampAvaticaParameterConverterTest {
     }
   }
 
+  @Test
+  public void testStaleRawTimestampIgnoredWhenTypedValueIsNotTimestamp() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    // Simulate stale map: rawTimestamp is present but TypedValue was set via setLong()
+    Timestamp staleTs = new Timestamp(TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+    staleTs.setNanos(869885001);
+
+    // A different value set via setLong — TypedValue type will be PRIMITIVE_LONG, not
+    // JAVA_SQL_TIMESTAMP
+    long longValue = 1774261392L;
+
+    try (TimeStampMicroVector vector = new TimeStampMicroVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue = TypedValue.ofLocal(ColumnMetaData.Rep.LONG, longValue);
+      // Even though staleTs is provided, the converter should ignore it because
+      // typedValue.type != JAVA_SQL_TIMESTAMP, and fall back to convertFromMillis
+      assertTrue(converter.bindParameter(vector, typedValue, 0, staleTs));
+      assertEquals(longValue * 1_000L, vector.get(0));
+    }
+  }
+
   private void assertBindConvertsMillis(TimeUnit unit, String tz, long expectedValue) {
     BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
     ArrowType.Timestamp type = new ArrowType.Timestamp(unit, tz);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
@@ -201,6 +201,51 @@ public class TimestampAvaticaParameterConverterTest {
     }
   }
 
+  @Test
+  public void testSecVectorNegativeEpochFloorDivision() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (TimeStampSecVector vector = new TimeStampSecVector("ts", allocator)) {
+      vector.allocateNew(3);
+      // -999 millis: regular division gives 0 (wrong), floorDiv gives -1 (correct)
+      TypedValue tv1 = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, -999L);
+      assertTrue(converter.bindParameter(vector, tv1, 0));
+      assertEquals(-1L, vector.get(0));
+
+      // -1000 millis: exactly -1 second
+      TypedValue tv2 = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, -1000L);
+      assertTrue(converter.bindParameter(vector, tv2, 1));
+      assertEquals(-1L, vector.get(1));
+
+      // -1001 millis: floorDiv gives -2 (correct), regular division gives -1 (wrong)
+      TypedValue tv3 = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, -1001L);
+      assertTrue(converter.bindParameter(vector, tv3, 2));
+      assertEquals(-2L, vector.get(2));
+    }
+  }
+
+  @Test
+  public void testNegativeEpochRawTimestampPreservesSubMillis() {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    // 1969-12-31 23:59:59.000123456 UTC → epochMillis=-1000, nanos=123456
+    // epochSeconds = floorDiv(-1000, 1000) = -1
+    // micros = -1 * 1_000_000 + 123456/1000 = -1_000_000 + 123 = -999877
+    Timestamp ts = new Timestamp(-1000L);
+    ts.setNanos(123456);
+
+    try (TimeStampMicroVector vector = new TimeStampMicroVector("ts", allocator)) {
+      vector.allocateNew(1);
+      TypedValue typedValue = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, -1000L);
+      assertTrue(converter.bindParameter(vector, typedValue, 0, ts));
+      assertEquals(-999877L, vector.get(0));
+    }
+  }
+
   private void assertBindConvertsMillis(TimeUnit unit, String tz, long expectedValue) {
     BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
     ArrowType.Timestamp type = new ArrowType.Timestamp(unit, tz);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverterTest.java
@@ -21,8 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestExtension;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.TimeStampNanoTZVector;
 import org.apache.arrow.vector.TimeStampNanoVector;
@@ -42,119 +45,52 @@ public class TimestampAvaticaParameterConverterTest {
   public static RootAllocatorTestExtension rootAllocatorTestExtension =
       new RootAllocatorTestExtension();
 
-  // A known epoch millis value: 2024-11-03 12:45:09.869 UTC
-  private static final long EPOCH_MILLIS = 1730637909869L;
+  // 2024-11-03 12:45:09.869 UTC — fractional seconds exercise the SECOND truncation path
+  private static final long TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS = 1730637909869L;
 
   @Test
-  public void testBindParameterMilliVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampMilliVector vector = new TimeStampMilliVector("ts", allocator)) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      assertEquals(EPOCH_MILLIS, vector.get(0));
-    }
+  public void testSecVector() {
+    assertBindConvertsMillis(
+        TimeUnit.SECOND, null, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS / 1_000L);
   }
 
   @Test
-  public void testBindParameterMicroVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampMicroVector vector = new TimeStampMicroVector("ts", allocator)) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      // Millis should be converted to micros
-      assertEquals(EPOCH_MILLIS * 1_000L, vector.get(0));
-    }
+  public void testMilliVector() {
+    assertBindConvertsMillis(TimeUnit.MILLISECOND, null, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
   }
 
   @Test
-  public void testBindParameterNanoVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.NANOSECOND, null);
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampNanoVector vector = new TimeStampNanoVector("ts", allocator)) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      // Millis should be converted to nanos
-      assertEquals(EPOCH_MILLIS * 1_000_000L, vector.get(0));
-    }
+  public void testMicroVector() {
+    assertBindConvertsMillis(
+        TimeUnit.MICROSECOND, null, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS * 1_000L);
   }
 
   @Test
-  public void testBindParameterSecVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, null);
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampSecVector vector = new TimeStampSecVector("ts", allocator)) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      // Millis should be converted to seconds
-      assertEquals(EPOCH_MILLIS / 1_000L, vector.get(0));
-    }
+  public void testNanoVector() {
+    assertBindConvertsMillis(
+        TimeUnit.NANOSECOND, null, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS * 1_000_000L);
   }
 
   @Test
-  public void testBindParameterMicroTZVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC");
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampMicroTZVector vector = new TimeStampMicroTZVector("ts", allocator, "UTC")) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      assertEquals(EPOCH_MILLIS * 1_000L, vector.get(0));
-    }
+  public void testSecTZVector() {
+    assertBindConvertsMillis(
+        TimeUnit.SECOND, "UTC", TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS / 1_000L);
   }
 
   @Test
-  public void testBindParameterNanoTZVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC");
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampNanoTZVector vector = new TimeStampNanoTZVector("ts", allocator, "UTC")) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      assertEquals(EPOCH_MILLIS * 1_000_000L, vector.get(0));
-    }
+  public void testMicroTZVector() {
+    assertBindConvertsMillis(
+        TimeUnit.MICROSECOND, "UTC", TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS * 1_000L);
   }
 
   @Test
-  public void testBindParameterSecTZVector() {
-    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
-    ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, "UTC");
-    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
-
-    try (TimeStampSecTZVector vector = new TimeStampSecTZVector("ts", allocator, "UTC")) {
-      vector.allocateNew(1);
-      TypedValue typedValue =
-          TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, EPOCH_MILLIS);
-      assertTrue(converter.bindParameter(vector, typedValue, 0));
-      assertEquals(EPOCH_MILLIS / 1_000L, vector.get(0));
-    }
+  public void testNanoTZVector() {
+    assertBindConvertsMillis(
+        TimeUnit.NANOSECOND, "UTC", TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS * 1_000_000L);
   }
 
   @Test
-  public void testBindParameterSecVectorTruncatesSubSecond() {
+  public void testSecVectorTruncatesSubSecond() {
     BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
     ArrowType.Timestamp type = new ArrowType.Timestamp(TimeUnit.SECOND, null);
     TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
@@ -162,10 +98,50 @@ public class TimestampAvaticaParameterConverterTest {
     try (TimeStampSecVector vector = new TimeStampSecVector("ts", allocator)) {
       vector.allocateNew(1);
       // 1999 millis should truncate to 1 second, not round to 2
-      long millis = 1999L;
-      TypedValue typedValue = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, millis);
+      TypedValue typedValue = TypedValue.ofLocal(ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, 1999L);
       assertTrue(converter.bindParameter(vector, typedValue, 0));
       assertEquals(1L, vector.get(0));
+    }
+  }
+
+  private void assertBindConvertsMillis(TimeUnit unit, String tz, long expectedValue) {
+    BufferAllocator allocator = rootAllocatorTestExtension.getRootAllocator();
+    ArrowType.Timestamp type = new ArrowType.Timestamp(unit, tz);
+    TimestampAvaticaParameterConverter converter = new TimestampAvaticaParameterConverter(type);
+
+    try (FieldVector vector = createTestTimestampVector(unit, tz, allocator)) {
+      ((BaseFixedWidthVector) vector).allocateNew(1);
+      TypedValue typedValue =
+          TypedValue.ofLocal(
+              ColumnMetaData.Rep.JAVA_SQL_TIMESTAMP, TEST_EPOCH_MILLIS_WITH_FRACTIONAL_SECONDS);
+      assertTrue(converter.bindParameter(vector, typedValue, 0));
+      long actual = vector.getDataBuffer().getLong(0);
+      assertEquals(expectedValue, actual);
+    }
+  }
+
+  private static FieldVector createTestTimestampVector(
+      TimeUnit unit, String tz, BufferAllocator allocator) {
+    boolean hasTz = tz != null;
+    switch (unit) {
+      case SECOND:
+        return hasTz
+            ? new TimeStampSecTZVector("ts", allocator, tz)
+            : new TimeStampSecVector("ts", allocator);
+      case MILLISECOND:
+        return hasTz
+            ? new TimeStampMilliTZVector("ts", allocator, tz)
+            : new TimeStampMilliVector("ts", allocator);
+      case MICROSECOND:
+        return hasTz
+            ? new TimeStampMicroTZVector("ts", allocator, tz)
+            : new TimeStampMicroVector("ts", allocator);
+      case NANOSECOND:
+        return hasTz
+            ? new TimeStampNanoTZVector("ts", allocator, tz)
+            : new TimeStampNanoVector("ts", allocator);
+      default:
+        throw new IllegalArgumentException("Unsupported time unit: " + unit);
     }
   }
 }


### PR DESCRIPTION
### Rationale for this change

The FlightSQL JDBC driver's `PreparedStatement.setTimestamp()` has two bugs (#838):

1. **Unit scaling bug**: `TimestampAvaticaParameterConverter` writes raw epoch millisecond values directly into Arrow timestamp vectors regardless of the vector's time unit. This causes data corruption when the server uses SECOND, MICROSECOND, or NANOSECOND precision — the millisecond value is misinterpreted as the target unit (e.g., epoch millis treated as epoch micros → dates near 1970).

2. **Precision loss bug**: The underlying Avatica library serializes `java.sql.Timestamp` into a `long` (epoch milliseconds) via `TypedValue.ofJdbc()`, discarding the sub-millisecond nanoseconds from `Timestamp.getNanos()` before they reach the Arrow converters. This means even with correct unit scaling, microsecond and nanosecond precision is permanently lost.

### What changes are included in this PR?

**Fix 1 — Unit scaling** (converter layer):
- Modified `TimestampAvaticaParameterConverter` to store the `ArrowType.Timestamp` and scale the epoch millisecond value to the target unit before writing to the vector:
  - SECOND: divide by 1,000 using `Math.floorDiv`
  - MILLISECOND: pass through
  - MICROSECOND: multiply by 1,000
  - NANOSECOND: multiply by 1,000,000

**Fix 2 — Sub-millisecond precision preservation** (JDBC interception layer):
- `ArrowFlightPreparedStatement`: Overrides `setTimestamp()` to capture the raw `java.sql.Timestamp` objects (with full nanosecond precision) before Avatica serializes them to millis. Also overrides `clearParameters()` to clean up.
- `ArrowFlightMetaImpl`: Added `getRawTimestamps()` to bridge the captured timestamps from the statement to the parameter binder.
- `AvaticaParameterBinder`: Updated `bind()` and `BinderVisitor` to propagate the optional raw `Timestamp` to converters.
- `TimestampAvaticaParameterConverter`: Added `bindParameter(vector, typedValue, index, rawTimestamp)` overload and `convertFromTimestamp(Timestamp)` that reconstructs full-precision epoch values from `Timestamp.getTime()` (epoch seconds) + `Timestamp.getNanos()` (fractional second in nanos), avoiding the Avatica millis truncation.
- `ListAvaticaParameterConverter`, `LargeListAvaticaParameterConverter`, `FixedSizeListAvaticaParameterConverter`: Updated to pass `null` as the raw timestamp argument to the new `BinderVisitor` constructor.

**Fix 3 — Stale raw timestamp handling** (overwrite edge cases):
- `ArrowFlightPreparedStatement`: Keeps the side-channel `rawTimestamps` map in sync for `setObject(...)` overwrites by clearing the affected entry.
- `TimestampAvaticaParameterConverter`: Only uses a `rawTimestamp` when the incoming `TypedValue.type` is still `JAVA_SQL_TIMESTAMP`, so stale side-channel entries are ignored if a later setter such as `setLong(...)` overwrites the parameter.

### Are these changes tested?

Yes.
- **Unit tests** (`TimestampAvaticaParameterConverterTest`): cover all Arrow timestamp vector units (with and without timezone) for millis-based scaling, the raw `Timestamp` path for micro/nano precision preservation and milli/second truncation, null-`rawTimestamp` fallback, negative epoch handling, and the stale-map case where a later non-timestamp setter must ignore a stale raw timestamp.
- **Integration tests** (`ArrowFlightPreparedStatementTest`): cover the full `setTimestamp()` → interception → binding → mock server validation path, plus overwrite scenarios including `setObject(...)` after `setTimestamp(...)`, `setLong(...)` after `setTimestamp(...)`, and `setTimestamp(...)` after `setObject(...)`.

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.** `PreparedStatement#setTimestamp()` now correctly converts timestamp values for non-millisecond precision columns. Previously, timestamps inserted via the FlightSQL JDBC driver into SECOND, MICROSECOND, or NANOSECOND columns were silently corrupted. Sub-millisecond precision (microseconds, nanoseconds) is now preserved when the target column supports it.

**This PR contains a "Critical Fix".** The bug caused incorrect data to be produced — epoch milliseconds were written as-is into microsecond/nanosecond vectors, resulting in wildly wrong dates (e.g., 2024 → 1970). Additionally, sub-millisecond precision was silently discarded.

Closes #838