### PR TITLE
GH-1098: [Java][Vector] Fix always-true precondition check in LargeListVector.setValueCount

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -1041,7 +1041,7 @@ public class LargeListVector extends BaseValueVector
      * TODO: revisit when 64-bit vectors are supported
      */
     Preconditions.checkArgument(
-        childValueCount <= Integer.MAX_VALUE || childValueCount >= Integer.MIN_VALUE,
+        childValueCount <= Integer.MAX_VALUE && childValueCount >= 0,
         "LargeListVector doesn't yet support 64-bit allocations: %s",
         childValueCount);
     vector.setValueCount((int) childValueCount);

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -1126,5 +1127,40 @@ public class TestLargeListVector {
       writer.integer().writeInt(v);
     }
     writer.endList();
+  }
+
+  @Test
+  public void testSetValueCountRejectsNegativeChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // Write a negative value into the offset buffer to simulate a corrupted offset
+      // that exceeds Integer.MAX_VALUE (which wraps to negative when read as long offset).
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, -1L);
+      vector.setLastSet(0);
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> vector.setValueCount(1),
+          "setValueCount should reject negative childValueCount");
+    }
+  }
+
+  @Test
+  public void testSetValueCountRejectsOverflowChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // Write a value exceeding Integer.MAX_VALUE into the offset buffer
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, (long) Integer.MAX_VALUE + 1L);
+      vector.setLastSet(0);
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> vector.setValueCount(1),
+          "setValueCount should reject childValueCount exceeding Integer.MAX_VALUE");
+    }
   }
 }


### PR DESCRIPTION
## What's Changed

Fix the precondition check in `LargeListVector.setValueCount()` where `||` made the condition always true (`childValueCount <= Integer.MAX_VALUE || childValueCount >= Integer.MIN_VALUE` is a tautology for any `long` value), allowing silent data corruption when `childValueCount` exceeds `Integer.MAX_VALUE` or is negative.

Changes:
- Replace `||` with `&&` and `Integer.MIN_VALUE` with `0` to correctly bound `childValueCount` to `[0, Integer.MAX_VALUE]`, consistent with `LargeListViewVector`
- Add rejection tests for negative and overflow `childValueCount`
- Add positive boundary tests for zero, valid, and `Integer.MAX_VALUE` values

Closes #1098.