### PR TITLE
GH-1098: [Java][Vector] Fix always-true precondition check in LargeListVector.setValueCount

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -1041,8 +1041,8 @@ public class LargeListVector extends BaseValueVector
      * TODO: revisit when 64-bit vectors are supported
      */
     Preconditions.checkArgument(
-        childValueCount <= Integer.MAX_VALUE && childValueCount >= 0,
-        "LargeListVector doesn't yet support 64-bit allocations: %s",
+        childValueCount >= 0 && childValueCount <= Integer.MAX_VALUE,
+        "LargeListVector childValueCount must be in [0, Integer.MAX_VALUE] but was: %s",
         childValueCount);
     vector.setValueCount((int) childValueCount);
   }

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -1041,7 +1041,7 @@ public class LargeListVector extends BaseValueVector
      * TODO: revisit when 64-bit vectors are supported
      */
     Preconditions.checkArgument(
-        childValueCount <= Integer.MAX_VALUE || childValueCount >= Integer.MIN_VALUE,
+        childValueCount <= Integer.MAX_VALUE && childValueCount >= 0,
         "LargeListVector doesn't yet support 64-bit allocations: %s",
         childValueCount);
     vector.setValueCount((int) childValueCount);

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -1126,5 +1127,91 @@ public class TestLargeListVector {
       writer.integer().writeInt(v);
     }
     writer.endList();
+  }
+
+  @Test
+  public void testSetValueCountRejectsNegativeChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // Write a negative value into the offset buffer to simulate a corrupted offset.
+      // The Preconditions check should reject any negative childValueCount.
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, -1L);
+      vector.setLastSet(0);
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> vector.setValueCount(1),
+          "setValueCount should reject negative childValueCount");
+    }
+  }
+
+  @Test
+  public void testSetValueCountRejectsOverflowChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // Write a value exceeding Integer.MAX_VALUE into the offset buffer
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, (long) Integer.MAX_VALUE + 1L);
+      vector.setLastSet(0);
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> vector.setValueCount(1),
+          "setValueCount should reject childValueCount exceeding Integer.MAX_VALUE");
+    }
+  }
+
+  @Test
+  public void testSetValueCountAcceptsZeroChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // childValueCount = 0 when valueCount = 0 (no elements)
+      vector.setValueCount(0);
+      assertEquals(0, vector.getValueCount());
+    }
+  }
+
+  @Test
+  public void testSetValueCountAcceptsValidChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // Write a valid childValueCount (5) into the offset buffer
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, 5L);
+      vector.setLastSet(0);
+      vector.setValueCount(1);
+      assertEquals(1, vector.getValueCount());
+    }
+  }
+
+  @Test
+  public void testSetValueCountAcceptsMaxIntChildValueCount() {
+    try (final LargeListVector vector = LargeListVector.empty("list", allocator)) {
+      vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      vector.allocateNew();
+
+      // Write Integer.MAX_VALUE into the offset buffer to verify the upper boundary is inclusive.
+      // The Preconditions check should accept this value (not throw IllegalArgumentException).
+      // The child vector may throw OversizedAllocationException due to memory limits,
+      // which is expected and unrelated to the precondition validation.
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, (long) Integer.MAX_VALUE);
+      vector.setLastSet(0);
+      try {
+        vector.setValueCount(1);
+      } catch (IllegalArgumentException e) {
+        throw new AssertionError(
+            "setValueCount should not reject childValueCount = Integer.MAX_VALUE", e);
+      } catch (Exception e) {
+        // OversizedAllocationException or other allocation errors are expected
+        // when trying to allocate Integer.MAX_VALUE elements — this is fine,
+        // the precondition check itself passed.
+      }
+    }
   }
 }

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -43,6 +45,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.util.OversizedAllocationException;
 import org.apache.arrow.vector.util.TransferPair;
 import org.apache.arrow.vector.util.UuidUtility;
 import org.junit.jupiter.api.AfterEach;
@@ -1200,14 +1203,13 @@ public class TestLargeListVector {
       // The Preconditions check should accept this value (not throw IllegalArgumentException).
       // The child vector may throw OversizedAllocationException due to memory limits,
       // which is expected and unrelated to the precondition validation.
-      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, (long) Integer.MAX_VALUE);
+      vector.getOffsetBuffer().setLong(LargeListVector.OFFSET_WIDTH, Integer.MAX_VALUE);
       vector.setLastSet(0);
       try {
         vector.setValueCount(1);
       } catch (IllegalArgumentException e) {
-        throw new AssertionError(
-            "setValueCount should not reject childValueCount = Integer.MAX_VALUE", e);
-      } catch (Exception e) {
+        fail("setValueCount should not reject childValueCount = Integer.MAX_VALUE", e);
+      } catch (OversizedAllocationException | OutOfMemoryException e) {
         // OversizedAllocationException or other allocation errors are expected
         // when trying to allocate Integer.MAX_VALUE elements — this is fine,
         // the precondition check itself passed.


### PR DESCRIPTION
## What's Changed

Fix the precondition check in `LargeListVector.setValueCount()` where `||` made the condition always true (`childValueCount <= Integer.MAX_VALUE || childValueCount >= Integer.MIN_VALUE` is a tautology for any `long` value), allowing silent data corruption when `childValueCount` exceeds `Integer.MAX_VALUE` or is negative.

Changes:
- Replace `||` with `&&` and `Integer.MIN_VALUE` with `0` to correctly bound `childValueCount` to `[0, Integer.MAX_VALUE]`, consistent with `LargeListViewVector`
- Add rejection tests for negative and overflow `childValueCount`
- Add positive boundary tests for zero, valid, and `Integer.MAX_VALUE` values

Closes #1098.