### PR TITLE
revert: downgrade Derby 10.17.1.0 → 10.15.2.0 (Java 19+ incompatibility)

### DIFF
--- a/adapter/avro/pom.xml
+++ b/adapter/avro/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/adapter/jdbc/pom.xml
+++ b/adapter/jdbc/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/adapter/orc/pom.xml
+++ b/adapter/orc/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/algorithm/pom.xml
+++ b/algorithm/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-algorithm</artifactId>
   <name>Arrow Algorithms</name>

--- a/arrow-variant/pom.xml
+++ b/arrow-variant/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-variant</artifactId>
   <name>Arrow Variant</name>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
   <groupId>org.apache.arrow</groupId>
   <artifactId>arrow-bom</artifactId>
-  <version>19.0.0-SNAPSHOT</version>
+  <version>19.0.0-iomete.1</version>
   <packaging>pom</packaging>
 
   <name>Arrow Bill of Materials</name>

--- a/c/pom.xml
+++ b/c/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-c-data</artifactId>

--- a/compression/pom.xml
+++ b/compression/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-compression</artifactId>
   <name>Arrow Compression</name>

--- a/dataset/pom.xml
+++ b/dataset/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-dataset</artifactId>

--- a/flight/flight-core/pom.xml
+++ b/flight/flight-core/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>flight-core</artifactId>

--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
@@ -185,6 +185,28 @@ public class NettyClientBuilder {
             "Scheme is not supported: " + location.getUri().getScheme());
     }
 
+    try {
+      configureChannel(builder);
+    } catch (SSLException e) {
+      throw new RuntimeException(e);
+    }
+    return builder;
+  }
+
+  /**
+   * Build a {@link NettyChannelBuilder} using {@code forTarget()} instead of {@code forAddress()}.
+   *
+   * <p>This is required for proxy support: only the DNS resolver path ({@code dns:///host:port})
+   * invokes the {@link io.grpc.ProxyDetector}. {@code forAddress()} bypasses it entirely.
+   */
+  public NettyChannelBuilder buildForTarget(String target) throws SSLException {
+    final NettyChannelBuilder builder = NettyChannelBuilder.forTarget(target);
+    configureChannel(builder);
+    return builder;
+  }
+
+  /** Apply TLS and message-size configuration to an already-created {@link NettyChannelBuilder}. */
+  protected void configureChannel(NettyChannelBuilder builder) throws SSLException {
     if (this.forceTls || LocationSchemes.GRPC_TLS.equals(location.getUri().getScheme())) {
       builder.useTransportSecurity();
 
@@ -210,11 +232,8 @@ public class NettyClientBuilder {
           sslContextBuilder.keyManager(this.clientCertificate, this.clientKey);
         }
       }
-      try {
-        builder.sslContext(sslContextBuilder.build());
-      } catch (SSLException e) {
-        throw new RuntimeException(e);
-      }
+
+      builder.sslContext(sslContextBuilder.build());
 
       if (this.overrideHostname != null) {
         builder.overrideAuthority(this.overrideHostname);
@@ -227,6 +246,5 @@ public class NettyClientBuilder {
         .maxTraceEvents(MAX_CHANNEL_TRACE_EVENTS)
         .maxInboundMessageSize(maxInboundMessageSize)
         .maxInboundMetadataSize(maxInboundMessageSize);
-    return builder;
   }
 }

--- a/flight/flight-integration-tests/pom.xml
+++ b/flight/flight-integration-tests/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>flight-integration-tests</artifactId>

--- a/flight/flight-sql-jdbc-core/pom.xml
+++ b/flight/flight-sql-jdbc-core/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>flight-sql-jdbc-core</artifactId>

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
@@ -128,6 +128,9 @@ public final class ArrowFlightConnection extends AvaticaConnection {
           .withConnectTimeout(config.getConnectTimeout())
           .withDriverVersion(driverVersion)
           .withOAuthConfiguration(config.getOauthConfiguration())
+          .withProxySettings(config.getProxyHost(), config.getProxyPort())
+          .withProxyBypassPattern(config.getProxyBypassPattern())
+          .withProxyDisable(config.getProxyDisable())
           .build();
     } catch (final SQLException e) {
       try {

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -38,6 +38,7 @@ import org.apache.arrow.driver.jdbc.client.oauth.OAuthTokenProvider;
 import org.apache.arrow.driver.jdbc.client.utils.ClientAuthenticationUtils;
 import org.apache.arrow.driver.jdbc.client.utils.FlightClientCache;
 import org.apache.arrow.driver.jdbc.client.utils.FlightLocationQueue;
+import org.apache.arrow.driver.jdbc.utils.ArrowFlightProxyDetector;
 import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.CloseSessionRequest;
@@ -693,6 +694,14 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
 
     DriverVersion driverVersion;
 
+    @VisibleForTesting String proxyHost;
+
+    @VisibleForTesting Integer proxyPort;
+
+    @VisibleForTesting String proxyBypassPattern;
+
+    @VisibleForTesting String proxyDisable;
+
     public Builder() {}
 
     /**
@@ -1000,6 +1009,63 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Sets the explicit proxy host and port for this connection.
+     *
+     * @param proxyHost the proxy hostname or IP, or {@code null} to clear
+     * @param proxyPort the proxy port, or {@code null} to clear
+     * @return this builder instance
+     */
+    public Builder withProxySettings(
+        @Nullable final String proxyHost, @Nullable final Integer proxyPort) {
+      this.proxyHost = proxyHost;
+      this.proxyPort = proxyPort;
+      return this;
+    }
+
+    /**
+     * Sets the proxy bypass pattern in {@code http.nonProxyHosts} format ({@code |}-separated glob
+     * patterns).
+     *
+     * @param proxyBypassPattern bypass pattern, or {@code null} to clear
+     * @return this builder instance
+     */
+    public Builder withProxyBypassPattern(@Nullable final String proxyBypassPattern) {
+      this.proxyBypassPattern = proxyBypassPattern;
+      return this;
+    }
+
+    /**
+     * Sets the proxy disable flag. Pass {@code "force"} to disable proxy even when system
+     * properties or environment variables configure one.
+     *
+     * @param proxyDisable disable flag value, or {@code null} to clear
+     * @return this builder instance
+     */
+    public Builder withProxyDisable(@Nullable final String proxyDisable) {
+      this.proxyDisable = proxyDisable;
+      return this;
+    }
+
+    private String getDnsTarget() {
+      // Validate port is in valid range (0-65535) before passing to gRPC.
+      // gRPC's DNS resolver validates the port on a background thread, but background thread
+      // exceptions do not propagate to the caller and prevent proper error handling.
+      if (port < 0 || port > 65535) {
+        throw new IllegalArgumentException("port out of range: " + port);
+      }
+      // IPv6 addresses need brackets in the URI authority component
+      String normalizedHost = host.contains(":") && !host.startsWith("[") ? "[" + host + "]" : host;
+      return "dns:///" + normalizedHost + ":" + port;
+    }
+
+    private NettyChannelBuilder getChannelBuilder(final NettyClientBuilder clientBuilder)
+        throws IOException {
+      // forTarget() ensures the DNS resolver is used, which invokes ProxyDetector.
+      // forAddress() bypasses it entirely.
+      return clientBuilder.buildForTarget(getDnsTarget());
+    }
+
     public String getCacheKey() {
       return getLocation().toString();
     }
@@ -1075,9 +1141,12 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
           }
         }
 
-        NettyChannelBuilder channelBuilder = clientBuilder.build();
+        NettyChannelBuilder channelBuilder = getChannelBuilder(clientBuilder);
 
         channelBuilder.userAgent(userAgent);
+        // Always install — returns null when no proxy is applicable, safe for all connections
+        channelBuilder.proxyDetector(
+            new ArrowFlightProxyDetector(proxyHost, proxyPort, proxyBypassPattern, proxyDisable));
 
         if (connectTimeout != null) {
           channelBuilder.withOption(

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -182,6 +182,22 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
     return ArrowFlightConnectionProperty.USE_CLIENT_CACHE.getBoolean(properties);
   }
 
+  public String getProxyHost() {
+    return ArrowFlightConnectionProperty.PROXY_HOST.getString(properties);
+  }
+
+  public Integer getProxyPort() {
+    return ArrowFlightConnectionProperty.PROXY_PORT.getInteger(properties);
+  }
+
+  public String getProxyBypassPattern() {
+    return ArrowFlightConnectionProperty.PROXY_BYPASS_PATTERN.getString(properties);
+  }
+
+  public String getProxyDisable() {
+    return ArrowFlightConnectionProperty.PROXY_DISABLE.getString(properties);
+  }
+
   /**
    * Gets the {@link CallOption}s from this {@link ConnectionConfig}.
    *
@@ -284,6 +300,10 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
     OAUTH_EXCHANGE_AUDIENCE("oauth.exchange.aud", null, Type.STRING, false),
     OAUTH_EXCHANGE_REQUESTED_TOKEN_TYPE(
         "oauth.exchange.requestedTokenType", null, Type.STRING, false),
+    PROXY_HOST("proxyHost", null, Type.STRING, false),
+    PROXY_PORT("proxyPort", null, Type.NUMBER, false),
+    PROXY_BYPASS_PATTERN("proxyBypassPattern", null, Type.STRING, false),
+    PROXY_DISABLE("proxyDisable", null, Type.STRING, false),
     ;
 
     private final String camelName;

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightProxyDetector.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightProxyDetector.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.driver.jdbc.utils;
+
+import io.grpc.HttpConnectProxiedSocketAddress;
+import io.grpc.ProxiedSocketAddress;
+import io.grpc.ProxyDetector;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * gRPC {@link ProxyDetector} for Arrow Flight JDBC connections.
+ *
+ * <p>Resolution priority:
+ *
+ * <ol>
+ *   <li>{@code proxyDisable=force} → no proxy (always)
+ *   <li>Target host matches {@code proxyBypassPattern} → no proxy
+ *   <li>Explicit {@code proxyHost} + {@code proxyPort} → use that proxy
+ *   <li>{@link ProxySelector} default → use first non-DIRECT proxy found
+ *   <li>No proxy
+ * </ol>
+ *
+ * <p>{@code proxyBypassPattern} follows the {@code http.nonProxyHosts} format: {@code |}-separated
+ * glob patterns where {@code *} matches any sequence of characters. Matching is case-insensitive.
+ */
+public final class ArrowFlightProxyDetector implements ProxyDetector {
+
+  @Nullable private final String proxyHost;
+  @Nullable private final Integer proxyPort;
+  @Nullable private final String bypassPattern;
+  private final boolean forceDisabled;
+  @Nullable private final ProxySelector proxySelector;
+
+  /** Production constructor — falls back to {@link ProxySelector#getDefault()}. */
+  public ArrowFlightProxyDetector(
+      @Nullable String proxyHost,
+      @Nullable Integer proxyPort,
+      @Nullable String bypassPattern,
+      @Nullable String proxyDisable) {
+    this(proxyHost, proxyPort, bypassPattern, proxyDisable, ProxySelector.getDefault());
+  }
+
+  /** Package-private constructor for testing — accepts an explicit {@link ProxySelector}. */
+  ArrowFlightProxyDetector(
+      @Nullable String proxyHost,
+      @Nullable Integer proxyPort,
+      @Nullable String bypassPattern,
+      @Nullable String proxyDisable,
+      @Nullable ProxySelector proxySelector) {
+    this.proxyHost = proxyHost;
+    this.proxyPort = proxyPort;
+    this.bypassPattern = bypassPattern;
+    this.forceDisabled = "force".equalsIgnoreCase(proxyDisable);
+    this.proxySelector = proxySelector;
+  }
+
+  @Override
+  @Nullable
+  public ProxiedSocketAddress proxyFor(SocketAddress targetAddress) throws IOException {
+    if (forceDisabled) {
+      return null;
+    }
+    InetSocketAddress inetTarget = (InetSocketAddress) targetAddress;
+    if (matchesBypass(inetTarget.getHostString())) {
+      return null;
+    }
+    InetSocketAddress proxyAddr = resolveProxy(inetTarget);
+    if (proxyAddr == null) {
+      return null;
+    }
+    return HttpConnectProxiedSocketAddress.newBuilder()
+        .setTargetAddress(inetTarget)
+        .setProxyAddress(proxyAddr)
+        .build();
+  }
+
+  /**
+   * Returns true if {@code host} matches any pattern in the bypass list.
+   *
+   * <p>Patterns use {@code http.nonProxyHosts} format: {@code |}-separated globs, where {@code *}
+   * is a wildcard for any sequence of characters.
+   */
+  private boolean matchesBypass(String host) {
+    if (bypassPattern == null || bypassPattern.isEmpty()) {
+      return false;
+    }
+    for (String pattern : bypassPattern.split("\\|")) {
+      String trimmed = pattern.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      // Convert glob to regex: escape dots, replace * with .*
+      String regex = trimmed.replace(".", "\\.").replace("*", ".*");
+      if (host.matches("(?i)" + regex)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Resolves which proxy address to use for the given target.
+   *
+   * <p>Tries explicit proxy first, then {@link ProxySelector}.
+   *
+   * @return resolved proxy address, or {@code null} if no proxy should be used
+   */
+  @Nullable
+  private InetSocketAddress resolveProxy(InetSocketAddress target) {
+    if (proxyHost != null && proxyPort != null) {
+      // new InetSocketAddress(String, int) resolves IP literals without DNS;
+      // for hostnames it attempts DNS — required since HttpConnectProxiedSocketAddress
+      // validates the proxy address is resolved.
+      return new InetSocketAddress(proxyHost, proxyPort);
+    }
+    if (proxySelector == null) {
+      return null;
+    }
+    URI uri;
+    try {
+      uri = new URI("https", null, target.getHostString(), target.getPort(), null, null, null);
+    } catch (URISyntaxException e) {
+      return null;
+    }
+    List<Proxy> proxies = proxySelector.select(uri);
+    for (Proxy proxy : proxies) {
+      if (proxy.type() != Proxy.Type.DIRECT && proxy.address() instanceof InetSocketAddress) {
+        return (InetSocketAddress) proxy.address();
+      }
+    }
+    return null;
+  }
+}

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
@@ -150,6 +150,12 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
     assertNull(builder.flightClientCache);
     assertNull(builder.connectTimeout);
     assertNull(builder.driverVersion);
+
+    // Proxy fields default to null
+    assertNull(builder.proxyHost);
+    assertNull(builder.proxyPort);
+    assertNull(builder.proxyBypassPattern);
+    assertNull(builder.proxyDisable);
   }
 
   @Test
@@ -174,5 +180,35 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
     rootBuilder.withCatalog(nameWithSpaces);
     assertTrue(rootBuilder.catalog.isPresent());
     assertEquals(nameWithSpaces, rootBuilder.catalog.get());
+  }
+
+  @Test
+  public void testProxyFieldsSetViaWithMethods() {
+    final ArrowFlightSqlClientHandler.Builder builder = new ArrowFlightSqlClientHandler.Builder();
+
+    builder.withProxySettings("proxy.corp.net", 8080);
+    assertEquals("proxy.corp.net", builder.proxyHost);
+    assertEquals(Integer.valueOf(8080), builder.proxyPort);
+
+    builder.withProxyBypassPattern("*.internal|localhost");
+    assertEquals("*.internal|localhost", builder.proxyBypassPattern);
+
+    builder.withProxyDisable("force");
+    assertEquals("force", builder.proxyDisable);
+  }
+
+  @Test
+  public void testProxySettingsAcceptNull() {
+    final ArrowFlightSqlClientHandler.Builder builder = new ArrowFlightSqlClientHandler.Builder();
+
+    builder.withProxySettings(null, null);
+    assertNull(builder.proxyHost);
+    assertNull(builder.proxyPort);
+
+    builder.withProxyBypassPattern(null);
+    assertNull(builder.proxyBypassPattern);
+
+    builder.withProxyDisable(null);
+    assertNull(builder.proxyDisable);
   }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightProxyDetectorTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightProxyDetectorTest.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.driver.jdbc.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.grpc.HttpConnectProxiedSocketAddress;
+import io.grpc.ProxiedSocketAddress;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ArrowFlightProxyDetector}. */
+class ArrowFlightProxyDetectorTest {
+
+  private static final InetSocketAddress TARGET =
+      InetSocketAddress.createUnresolved("dev.iomete.cloud", 443);
+
+  // Use IP literals — InetSocketAddress resolves them without DNS, avoiding test-env failures.
+  // HttpConnectProxiedSocketAddress requires a resolved proxy address.
+  private static final String PROXY_HOST = "192.168.1.1";
+  private static final int PROXY_PORT = 8080;
+
+  @Nested
+  // force disabled nullifies explicit proxy; force disabled overrides ProxySelector
+  class ForceDisabled {
+
+    @Test
+    void givenForceDisabled_whenProxyFor_thenReturnsNull() throws IOException {
+      // GIVEN: force disabled with explicit proxy configured
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(PROXY_HOST, PROXY_PORT, null, "force", noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertNull(result);
+    }
+
+    @Test
+    void givenForceDisabledAndProxySelectorReturnsProxy_whenProxyFor_thenReturnsNull()
+        throws IOException {
+      // GIVEN: force disabled overrides even ProxySelector
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              null, null, null, "force", proxySelectorReturning("192.168.1.2", 3128));
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertNull(result);
+    }
+  }
+
+  @Nested
+  // returns configured proxy address; preserves target address
+  class ExplicitProxy {
+
+    @Test
+    void givenExplicitProxy_whenProxyFor_thenReturnsConfiguredProxy() throws IOException {
+      // GIVEN: explicit proxyHost + proxyPort
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(PROXY_HOST, PROXY_PORT, null, null, noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertProxyAddress(result, PROXY_HOST, PROXY_PORT);
+    }
+
+    @Test
+    void givenExplicitProxy_whenProxyFor_thenTargetAddressPreserved() throws IOException {
+      // GIVEN: explicit proxy
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(PROXY_HOST, PROXY_PORT, null, null, noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN: target address is forwarded through the proxy
+      HttpConnectProxiedSocketAddress httpProxy =
+          assertInstanceOf(HttpConnectProxiedSocketAddress.class, result);
+      assertEquals(TARGET, httpProxy.getTargetAddress());
+    }
+  }
+
+  @Nested
+  // matching pattern bypasses proxy; non-matching pattern allows proxy; multiple pipe-separated
+  // patterns; case-insensitive matching
+  class BypassPattern {
+
+    @Test
+    void givenBypassMatchesTarget_whenProxyFor_thenReturnsNull() throws IOException {
+      // GIVEN: bypass pattern matches target, explicit proxy configured
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST, PROXY_PORT, "*.iomete.cloud", null, noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN: bypass wins over explicit proxy
+      assertNull(result);
+    }
+
+    @Test
+    void givenBypassDoesNotMatchTarget_whenProxyFor_thenReturnsProxy() throws IOException {
+      // GIVEN: bypass pattern does NOT match target
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST, PROXY_PORT, "*.internal.net", null, noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result =
+          sut.proxyFor(InetSocketAddress.createUnresolved("api.example.com", 443));
+
+      // THEN
+      assertProxyAddress(result, PROXY_HOST, PROXY_PORT);
+    }
+
+    @Test
+    void givenMultipleBypassPatterns_whenProxyFor_thenAnyMatchBypasses() throws IOException {
+      // GIVEN: pipe-separated patterns (http.nonProxyHosts format)
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST,
+              PROXY_PORT,
+              "localhost|*.internal|10.*|exact.host.com",
+              null,
+              noProxySelector());
+
+      // THEN: each pattern type is tested
+      assertNull(sut.proxyFor(InetSocketAddress.createUnresolved("localhost", 443)), "exact match");
+      assertNull(
+          sut.proxyFor(InetSocketAddress.createUnresolved("db.internal", 5432)), "suffix wildcard");
+      assertNull(
+          sut.proxyFor(InetSocketAddress.createUnresolved("10.0.0.1", 443)), "prefix wildcard");
+      assertNull(
+          sut.proxyFor(InetSocketAddress.createUnresolved("exact.host.com", 443)),
+          "exact FQDN match");
+
+      // non-matching host goes through proxy
+      assertNotNull(
+          sut.proxyFor(InetSocketAddress.createUnresolved("external.com", 443)),
+          "non-matching host should use proxy");
+    }
+
+    @Test
+    void givenBypassPatternIsCaseInsensitive_whenProxyFor_thenMatchesRegardlessOfCase()
+        throws IOException {
+      // GIVEN: mixed-case bypass vs mixed-case target
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST, PROXY_PORT, "*.Example.COM", null, noProxySelector());
+
+      // THEN
+      assertNull(sut.proxyFor(InetSocketAddress.createUnresolved("API.EXAMPLE.COM", 443)));
+      assertNull(sut.proxyFor(InetSocketAddress.createUnresolved("api.example.com", 443)));
+    }
+  }
+
+  @Nested
+  // uses selector when no explicit proxy; null when selector returns DIRECT; picks first non-DIRECT
+  // from multi-proxy list; handles null ProxySelector
+  class ProxySelectorFallback {
+
+    @Test
+    void givenNoExplicitProxyAndSelectorReturnsProxy_whenProxyFor_thenUsesSelector()
+        throws IOException {
+      // GIVEN: no explicit proxy, ProxySelector returns an HTTP proxy
+      String selectorHost = "192.168.1.2";
+      int selectorPort = 3128;
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              null, null, null, null, proxySelectorReturning(selectorHost, selectorPort));
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertProxyAddress(result, selectorHost, selectorPort);
+    }
+
+    @Test
+    void givenNoExplicitProxyAndSelectorReturnsDirect_whenProxyFor_thenReturnsNull()
+        throws IOException {
+      // GIVEN: ProxySelector returns DIRECT (no proxy)
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(null, null, null, null, noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertNull(result);
+    }
+
+    @Test
+    void givenNoExplicitProxyAndSelectorReturnsMultiple_whenProxyFor_thenUsesFirstNonDirect()
+        throws IOException {
+      // GIVEN: ProxySelector returns [DIRECT, HTTP proxy]
+      ProxySelector selector = mock(ProxySelector.class);
+      InetSocketAddress proxyAddr = new InetSocketAddress("192.168.1.3", 9090);
+      List<Proxy> proxies = List.of(Proxy.NO_PROXY, new Proxy(Proxy.Type.HTTP, proxyAddr));
+      when(selector.select(any(URI.class))).thenReturn(proxies);
+
+      ArrowFlightProxyDetector sut = new ArrowFlightProxyDetector(null, null, null, null, selector);
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN: skips DIRECT, uses the HTTP proxy
+      assertProxyAddress(result, "192.168.1.3", 9090);
+    }
+
+    @Test
+    void givenNullProxySelector_whenProxyFor_thenReturnsNull() throws IOException {
+      // GIVEN: null ProxySelector (can happen if JVM has no default)
+      ArrowFlightProxyDetector sut = new ArrowFlightProxyDetector(null, null, null, null, null);
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertNull(result);
+    }
+  }
+
+  @Nested
+  // returns null when nothing is configured
+  class NoProxyConfigured {
+
+    @Test
+    void givenNothingConfigured_whenProxyFor_thenReturnsNull() throws IOException {
+      // GIVEN: no proxy, no bypass, not disabled, selector returns DIRECT
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(null, null, null, null, noProxySelector());
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN
+      assertNull(result);
+    }
+  }
+
+  @Nested
+  // forceDisabled > bypass > explicit > selector
+  class PriorityOrder {
+
+    @Test
+    void givenForceDisabledWithExplicitProxyAndBypass_whenProxyFor_thenForceDisabledWins()
+        throws IOException {
+      // GIVEN: all settings configured, force disabled takes highest priority
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST,
+              PROXY_PORT,
+              "*.other.com",
+              "force",
+              proxySelectorReturning("192.168.1.2", 3128));
+
+      // THEN
+      assertNull(sut.proxyFor(TARGET));
+    }
+
+    @Test
+    void givenBypassMatchesAndExplicitProxy_whenProxyFor_thenBypassWins() throws IOException {
+      // GIVEN: target matches bypass, explicit proxy also configured
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST,
+              PROXY_PORT,
+              "*.iomete.cloud",
+              null,
+              proxySelectorReturning("192.168.1.2", 3128));
+
+      // THEN: bypass takes priority over explicit proxy
+      assertNull(sut.proxyFor(TARGET));
+    }
+
+    @Test
+    void givenExplicitProxyAndSelector_whenProxyFor_thenExplicitWins() throws IOException {
+      // GIVEN: both explicit proxy and ProxySelector configured
+      ArrowFlightProxyDetector sut =
+          new ArrowFlightProxyDetector(
+              PROXY_HOST, PROXY_PORT, null, null, proxySelectorReturning("192.168.1.2", 3128));
+
+      // WHEN
+      ProxiedSocketAddress result = sut.proxyFor(TARGET);
+
+      // THEN: explicit proxy takes priority over selector
+      assertProxyAddress(result, PROXY_HOST, PROXY_PORT);
+    }
+  }
+
+  private static ProxySelector noProxySelector() {
+    ProxySelector selector = mock(ProxySelector.class);
+    when(selector.select(any(URI.class))).thenReturn(Collections.singletonList(Proxy.NO_PROXY));
+    return selector;
+  }
+
+  private static ProxySelector proxySelectorReturning(String host, int port) {
+    ProxySelector selector = mock(ProxySelector.class);
+    InetSocketAddress proxyAddr = new InetSocketAddress(host, port);
+    Proxy proxy = new Proxy(Proxy.Type.HTTP, proxyAddr);
+    when(selector.select(any(URI.class))).thenReturn(Collections.singletonList(proxy));
+    return selector;
+  }
+
+  private static void assertProxyAddress(
+      ProxiedSocketAddress result, String expectedHost, int expectedPort) {
+    assertNotNull(result);
+    HttpConnectProxiedSocketAddress httpProxy =
+        assertInstanceOf(HttpConnectProxiedSocketAddress.class, result);
+    InetSocketAddress proxyAddr = (InetSocketAddress) httpProxy.getProxyAddress();
+    assertEquals(expectedHost, proxyAddr.getHostString());
+    assertEquals(expectedPort, proxyAddr.getPort());
+  }
+}

--- a/flight/flight-sql-jdbc-driver/pom.xml
+++ b/flight/flight-sql-jdbc-driver/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>flight-sql-jdbc-driver</artifactId>
@@ -138,6 +138,14 @@ under the License.
                 </relocation>
               </relocations>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Built-By>IOMETE</Built-By>
+                    <Implementation-Vendor>IOMETE</Implementation-Vendor>
+                    <Implementation-Version>19.0.0-iomete.1</Implementation-Version>
+                    <X-Fork-Source>Apache Arrow Java 19.0.0</X-Fork-Source>
+                  </manifestEntries>
+                </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                   <resource>META-INF/LICENSE.txt</resource>

--- a/flight/flight-sql/pom.xml
+++ b/flight/flight-sql/pom.xml
@@ -89,7 +89,7 @@ under the License.
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.15.2.0</version>
+      <version>10.17.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/flight/flight-sql/pom.xml
+++ b/flight/flight-sql/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>flight-sql</artifactId>

--- a/flight/flight-sql/pom.xml
+++ b/flight/flight-sql/pom.xml
@@ -89,7 +89,7 @@ under the License.
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.17.1.0</version>
+      <version>10.15.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/flight/pom.xml
+++ b/flight/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-flight</artifactId>
 

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-format</artifactId>

--- a/gandiva/pom.xml
+++ b/gandiva/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <groupId>org.apache.arrow.gandiva</groupId>

--- a/memory/memory-core/pom.xml
+++ b/memory/memory-core/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-memory</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-memory-core</artifactId>

--- a/memory/memory-netty-buffer-patch/pom.xml
+++ b/memory/memory-netty-buffer-patch/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-memory</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-memory-netty-buffer-patch</artifactId>

--- a/memory/memory-netty/pom.xml
+++ b/memory/memory-netty/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-memory</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-memory-netty</artifactId>

--- a/memory/memory-unsafe/pom.xml
+++ b/memory/memory-unsafe/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-memory</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
 
   <artifactId>arrow-memory-unsafe</artifactId>

--- a/memory/pom.xml
+++ b/memory/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-memory</artifactId>
   <packaging>pom</packaging>

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-17"

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-performance</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
   <groupId>org.apache.arrow</groupId>
   <artifactId>arrow-java-root</artifactId>
-  <version>19.0.0-SNAPSHOT</version>
+  <version>19.0.0-iomete.1</version>
   <packaging>pom</packaging>
 
   <name>Apache Arrow Java Root POM</name>
@@ -92,7 +92,7 @@ under the License.
   </issueManagement>
 
   <properties>
-    <project.build.outputTimestamp>1695310533</project.build.outputTimestamp>
+    <project.build.outputTimestamp>1773860567</project.build.outputTimestamp>
     <target.gen.source.path>${project.build.directory}/generated-sources</target.gen.source.path>
     <dep.junit.platform.version>1.9.0</dep.junit.platform.version>
     <dep.junit.jupiter.version>5.12.2</dep.junit.jupiter.version>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-tools</artifactId>
   <name>Arrow Tools</name>

--- a/vector/pom.xml
+++ b/vector/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>19.0.0-SNAPSHOT</version>
+    <version>19.0.0-iomete.1</version>
   </parent>
   <artifactId>arrow-vector</artifactId>
   <name>Arrow Vectors</name>


### PR DESCRIPTION
## Summary

- Reverts dependabot bump b8b597a0 that upgraded Derby from `10.15.2.0` to `10.17.1.0`
- Derby 10.17.1.0 requires Java 19+ due to use of restricted `sun.misc.Unsafe` APIs — breaks builds on our current JDK target
- No backport has been released by Derby maintainers (fix exists in repo but was never shipped); Derby is effectively unmaintained

## Context

Derby is a **test-scope only** dependency in `flight/flight-sql` — it is not shipped to users. This was discussed in the daily sync and needs to be annotated in Vanta accordingly.

## Options considered

| Option | Notes |
|--------|-------|
| ✅ **Revert (this PR)** | Unblocks builds immediately; accept risk given test-scope |
| Remove Derby + disable tests | Cleaner long-term if we don't need it |
| Replace with H2 | More actively maintained embedded DB |
| Manage our own Derby `10.16.1.2` release | Full control but high maintenance burden |
| Upgrade arrow-java/JDBC to JDK-21 | Would allow keeping `10.17.1.0`; larger scope change |

## Follow-up

- [ ] Annotate in Vanta: test-scope dependency, originates from upstream arrow-java fork, not shipped to users
- [ ] Decide long-term Derby strategy (see options above)

## Test plan

- [ ] Build passes on current JDK target after revert
- [ ] `flight/flight-sql` tests pass with Derby `10.15.2.0`