### PR TITLE
GH-1107: Increase publish job timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - name: Download RC contents
         run: |


### PR DESCRIPTION
## What's Changed

We have many artifacts and need `sleep 1` per upload. So 5min timeout is too short.

Closes #1107.
