### PR TITLE
GH-1039: [Flight] Fix ClassCastException when building FlightClient with domain socket location

### DIFF
--- a/flight/flight-core/pom.xml
+++ b/flight/flight-core/pom.xml
@@ -147,6 +147,39 @@ under the License.
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>native-epoll-test</id>
+      <activation>
+        <os><family>linux</family></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${dep.netty-bom.version}</version>
+          <classifier>${os.detected.classifier}</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>native-kqueue-test</id>
+      <activation>
+        <os><family>mac</family></os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${dep.netty-bom.version}</version>
+          <classifier>${os.detected.classifier}</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/flight/flight-core/pom.xml
+++ b/flight/flight-core/pom.xml
@@ -147,39 +147,6 @@ under the License.
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>native-epoll-test</id>
-      <activation>
-        <os><family>linux</family></os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${dep.netty-bom.version}</version>
-          <classifier>${os.detected.classifier}</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>native-kqueue-test</id>
-      <activation>
-        <os><family>mac</family></os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${dep.netty-bom.version}</version>
-          <classifier>${os.detected.classifier}</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>
@@ -235,4 +202,41 @@ under the License.
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>native-epoll-test</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${dep.netty-bom.version}</version>
+          <classifier>${os.detected.classifier}</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>native-kqueue-test</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${dep.netty-bom.version}</version>
+          <classifier>${os.detected.classifier}</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
@@ -19,8 +19,8 @@ package org.apache.arrow.flight.grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.io.InputStream;
@@ -151,7 +151,7 @@ public class NettyClientBuilder {
               // Linux
               builder.channelType(
                   Class.forName("io.netty.channel.epoll.EpollDomainSocketChannel")
-                      .asSubclass(ServerChannel.class));
+                      .asSubclass(Channel.class));
               final EventLoopGroup elg =
                   Class.forName("io.netty.channel.epoll.EpollEventLoopGroup")
                       .asSubclass(EventLoopGroup.class)
@@ -162,7 +162,7 @@ public class NettyClientBuilder {
               // BSD
               builder.channelType(
                   Class.forName("io.netty.channel.kqueue.KQueueDomainSocketChannel")
-                      .asSubclass(ServerChannel.class));
+                      .asSubclass(Channel.class));
               final EventLoopGroup elg =
                   Class.forName("io.netty.channel.kqueue.KQueueEventLoopGroup")
                       .asSubclass(EventLoopGroup.class)


### PR DESCRIPTION
## What's Changed

Fix a `ClassCastException` on`FlightClient.builder().build()` when connecting via a Unix domain socket on Linux (epoll) or macOS (kqueue), by casting to the Netty interface `Channel` instead of the server-specific `ServerChannel`.
  
Also adds netty-transport-native-epoll (Linux) and netty-transport-native-kqueue (macOS) as test-scoped dependencies in flight-core via OS-activated profiles, so the existing `TestServerOptions#domainSocket` test actually runs instead of being skipped everywhere.  

This change was created with AI assistance (Claude Code). All lines were manually reviewed by a human. The output is not copyrightable subject matter.

Closes #1039.
