### PR TITLE
GH-44: Clear signature columns before re-populating in ArrowFlightStatement#executeFlightInfoQuery

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightStatement.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightStatement.java
@@ -52,6 +52,7 @@ public class ArrowFlightStatement extends AvaticaStatement implements ArrowFligh
     }
 
     final Schema resultSetSchema = preparedStatement.getDataSetSchema();
+    signature.columns.clear();
     signature.columns.addAll(
         ConvertUtils.convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields()));
     setSignature(signature);

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetMetadataTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetMetadataTest.java
@@ -220,4 +220,23 @@ public class ResultSetMetadataTest {
   public void testShouldGetColumnTypesFromOutOfBoundIndex() {
     assertThrows(IndexOutOfBoundsException.class, () -> metadata.getColumnType(4));
   }
+
+  /**
+   * Regression test for <a href="https://github.com/apache/arrow-java/issues/44">issue #44</a>:
+   * {@code ArrowFlightStatement#executeFlightInfoQuery} appends schema columns to the reused {@code
+   * Meta.Signature} without clearing the existing list. When the result has at least one endpoint,
+   * the {@code FlightStream} consumption path overwrites {@code signature.columns} from the actual
+   * stream schema and hides the duplication. With an empty endpoint list — the scenario reported
+   * against both Rust- and Denodo-based Flight SQL servers — that overwrite never runs and {@code
+   * ResultSetMetaData#getColumnCount()} reports double the schema width.
+   */
+  @Test
+  public void testShouldNotDuplicateColumnsWhenFlightInfoHasNoEndpoints() throws SQLException {
+    try (Connection conn = FLIGHT_SERVER_TEST_EXTENSION.getConnection(false);
+        Statement st = conn.createStatement();
+        ResultSet rs =
+            st.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_NO_ENDPOINTS_SQL_CMD)) {
+      assertThat(rs.getMetaData().getColumnCount(), equalTo(1));
+    }
+  }
 }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/CoreMockedSqlProducers.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/CoreMockedSqlProducers.java
@@ -67,6 +67,8 @@ public final class CoreMockedSqlProducers {
   public static final String LEGACY_METADATA_SQL_CMD = "SELECT * FROM METADATA";
   public static final String LEGACY_CANCELLATION_SQL_CMD = "SELECT * FROM TAKES_FOREVER";
   public static final String LEGACY_REGULAR_WITH_EMPTY_SQL_CMD = "SELECT * FROM TEST_EMPTIES";
+  public static final String LEGACY_REGULAR_NO_ENDPOINTS_SQL_CMD =
+      "SELECT * FROM TEST_NO_ENDPOINTS";
 
   public static final String UUID_SQL_CMD = "SELECT * FROM UUID_TABLE";
   public static final String UUID_PREPARED_SELECT_SQL_CMD =
@@ -100,10 +102,20 @@ public final class CoreMockedSqlProducers {
     addLegacyMetadataSqlCmdSupport(producer);
     addLegacyCancellationSqlCmdSupport(producer);
     addQueryWithEmbeddedEmptyRoot(producer);
+    addQueryWithNoEndpoints(producer);
     addUuidSqlCmdSupport(producer);
     addUuidPreparedSelectSqlCmdSupport(producer);
     addUuidPreparedUpdateSqlCmdSupport(producer);
     return producer;
+  }
+
+  private static void addQueryWithNoEndpoints(final MockFlightSqlProducer producer) {
+    final Schema querySchema =
+        new Schema(
+            ImmutableList.of(
+                new Field("ID", new FieldType(true, new ArrowType.Int(64, true), null), null)));
+    producer.addSelectQuery(
+        LEGACY_REGULAR_NO_ENDPOINTS_SQL_CMD, querySchema, Collections.emptyList());
   }
 
   /**


### PR DESCRIPTION
## Rationale

`ArrowFlightStatement#executeFlightInfoQuery` appends the dataset schema columns to the statement's reused `Meta.Signature` without first clearing them, so the column list doubles on every invocation. When the `FlightInfo` has at least one endpoint, `ArrowFlightJdbcVectorSchemaRootResultSet#populateData` overwrites `signature.columns` from the actual stream schema and hides the duplication. With an empty endpoint list — the case reported by @mingnuj in the original issue against a Rust-based Flight SQL server, and independently reproducible against Denodo Express 9.4.2 — that overwrite never runs, and `ResultSetMetaData#getColumnCount()` reports `2× columnCount`. Calcite/Avatica then refuses the metadata with `Cannot have more columns with the same name`.

This is a regression introduced in 15.0.0 by the prepared-statement parameter binding work in [GH-33475](https://github.com/apache/arrow/pull/38404), which made `handle.signature` mutable and shared across the `prepareAndExecute` → `executeFlightInfoQuery` path.

## Fix

One line: `signature.columns.clear()` before the existing `addAll(...)`. The fresh schema returned at execute time is authoritative; pre-existing entries on the signature are stale by definition. This is exactly the workaround @mingnuj proposed in the issue and confirmed working.

## Test

Adds `ResultSetMetadataTest#testShouldNotDuplicateColumnsWhenFlightInfoHasNoEndpoints` plus a `LEGACY_REGULAR_NO_ENDPOINTS_SQL_CMD` fixture in `CoreMockedSqlProducers` (registered with an empty result-provider list, so `getFlightInfoStatement` returns a `FlightInfo` with zero endpoints — the bug-triggering shape). The test asserts `getColumnCount() == 1`, fails on `main` with `Expected: <1> but was <2>`, and passes after the fix.

`./gradlew`-equivalent run for this module:
```
mvn -pl flight/flight-sql-jdbc-core test
```
Result: 1234 tests run, 0 failures, 0 errors, 44 skipped.

## Cross-server reproductions

The bug surfaces against any Flight SQL server that returns an empty endpoint list:
- Rust-based server in @mingnuj's original report.
- Denodo Express 9.4.2 (independent reproduction over JDBC).

Wire-level the same `FlightInfo` is parsed correctly as 1 column by `pyarrow.flight`, by ADBC C++ / Python, and by Denodo's own native JDBC driver — only `flight-sql-jdbc-driver` 18.x / 19.0.0 doubles the column count, confirming the issue is Java-side.

Closes #44.