### PR TITLE
GH-1109: Fix ComplexCopier for extension-type holder readers

### DIFF
--- a/arrow-variant/src/main/java/org/apache/arrow/variant/impl/NullableVariantHolderReaderImpl.java
+++ b/arrow-variant/src/main/java/org/apache/arrow/variant/impl/NullableVariantHolderReaderImpl.java
@@ -19,6 +19,7 @@ package org.apache.arrow.variant.impl;
 import org.apache.arrow.variant.holders.NullableVariantHolder;
 import org.apache.arrow.vector.complex.impl.AbstractFieldReader;
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 public class NullableVariantHolderReaderImpl extends AbstractFieldReader {
   private final NullableVariantHolder holder;
@@ -45,6 +46,11 @@ public class NullableVariantHolderReaderImpl extends AbstractFieldReader {
   @Override
   public Types.MinorType getMinorType() {
     return Types.MinorType.EXTENSIONTYPE;
+  }
+
+  @Override
+  public ArrowType getExtensionType() {
+    return holder.type();
   }
 
   @Override

--- a/arrow-variant/src/test/java/org/apache/arrow/variant/extension/TestVariantVector.java
+++ b/arrow-variant/src/test/java/org/apache/arrow/variant/extension/TestVariantVector.java
@@ -30,6 +30,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.variant.Variant;
 import org.apache.arrow.variant.holders.NullableVariantHolder;
 import org.apache.arrow.variant.holders.VariantHolder;
+import org.apache.arrow.variant.impl.NullableVariantHolderReaderImpl;
 import org.apache.arrow.variant.impl.VariantReaderImpl;
 import org.apache.arrow.variant.impl.VariantWriterImpl;
 import org.apache.arrow.vector.holders.ExtensionHolder;
@@ -840,5 +841,17 @@ class TestVariantVector {
       // After clear, vector should be empty
       assertEquals(0, vector.getValueCount());
     }
+  }
+
+  /**
+   * Holder readers must expose their extension {@link ArrowType} via {@code getExtensionType()} so
+   * callers (notably {@code ComplexCopier}) can route values through union/promotable writers
+   * without depending on {@code getField()}, which is undefined for holder-backed readers.
+   */
+  @Test
+  void testNullableVariantHolderReaderImplGetExtensionType() {
+    NullableVariantHolder holder = new NullableVariantHolder();
+    NullableVariantHolderReaderImpl reader = new NullableVariantHolderReaderImpl(holder);
+    assertEquals(VariantType.INSTANCE, reader.getExtensionType());
   }
 }

--- a/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/vector/src/main/codegen/templates/ComplexCopier.java
@@ -111,7 +111,9 @@ public class ComplexCopier {
         if (reader.isSet()) {
           Object value = reader.readObject();
           if (value != null) {
-            writer.writeExtension(value, reader.getField().getType());
+            // Use getExtensionType() rather than getField().getType(): holder-backed
+            // readers carry their type on the ExtensionHolder and have no Field.
+            writer.writeExtension(value, reader.getExtensionType());
           }
         } else {
           writer.writeNull();
@@ -170,7 +172,7 @@ public class ComplexCopier {
     case LISTVIEW:
       return (FieldWriter) writer.listView(name);
     case EXTENSIONTYPE:
-      ExtensionWriter extensionWriter = writer.extension(name, reader.getField().getType());
+      ExtensionWriter extensionWriter = writer.extension(name, reader.getExtensionType());
       return (FieldWriter) extensionWriter;
     default:
       throw new UnsupportedOperationException(reader.getMinorType().toString());
@@ -197,7 +199,7 @@ public class ComplexCopier {
     case LISTVIEW:
       return (FieldWriter) writer.listView();
     case EXTENSIONTYPE:
-      ExtensionWriter extensionWriter = writer.extension(reader.getField().getType());
+      ExtensionWriter extensionWriter = writer.extension(reader.getExtensionType());
       return (FieldWriter) extensionWriter;
     default:
       throw new UnsupportedOperationException(reader.getMinorType().toString());
@@ -225,7 +227,7 @@ public class ComplexCopier {
       case MAP:
         return (FieldWriter) writer.map(false);
       case EXTENSIONTYPE:
-        ExtensionWriter extensionWriter = writer.extension(reader.getField().getType());
+        ExtensionWriter extensionWriter = writer.extension(reader.getExtensionType());
         return (FieldWriter) extensionWriter;
       default:
         throw new UnsupportedOperationException(reader.getMinorType().toString());

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableUuidHolderReaderImpl.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableUuidHolderReaderImpl.java
@@ -20,6 +20,7 @@ import org.apache.arrow.vector.holders.ExtensionHolder;
 import org.apache.arrow.vector.holders.NullableUuidHolder;
 import org.apache.arrow.vector.holders.UuidHolder;
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.util.UuidUtility;
 
 /**
@@ -70,6 +71,11 @@ public class NullableUuidHolderReaderImpl extends AbstractFieldReader {
   @Override
   public Types.MinorType getMinorType() {
     return Types.MinorType.EXTENSIONTYPE;
+  }
+
+  @Override
+  public ArrowType getExtensionType() {
+    return holder.type();
   }
 
   @Override

--- a/vector/src/main/java/org/apache/arrow/vector/complex/reader/ExtensionReader.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/reader/ExtensionReader.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.vector.complex.reader;
 
 import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /** Interface for reading extension types. Extends the functionality of {@link BaseReader}. */
 public interface ExtensionReader extends BaseReader {
@@ -41,4 +42,21 @@ public interface ExtensionReader extends BaseReader {
    * @return true if the value is set, false otherwise
    */
   boolean isSet();
+
+  /**
+   * Returns the {@link ArrowType} of the extension data this reader exposes.
+   *
+   * <p>The default derives the type from {@link #getField()}, which works for vector-backed
+   * readers. Holder-backed readers (which have no notion of a {@code Field}) must override this to
+   * return the type carried by their {@link ExtensionHolder} directly.
+   *
+   * <p>Callers that need the extension {@link ArrowType} (e.g. to route a value through a union or
+   * promotable writer) should prefer this over {@code getField().getType()} so the call is
+   * well-defined regardless of how the reader is backed.
+   *
+   * @return the extension {@link ArrowType}
+   */
+  default ArrowType getExtensionType() {
+    return getField().getType();
+  }
 }

--- a/vector/src/test/java/org/apache/arrow/vector/TestUuidVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestUuidVector.java
@@ -723,4 +723,16 @@ class TestUuidVector {
       assertEquals(uuid2, UuidUtility.uuidFromArrowBuf(targetHolder.buffer, targetHolder.start));
     }
   }
+
+  /**
+   * Holder readers must expose their extension {@link ArrowType} via {@code getExtensionType()} so
+   * callers (notably {@code ComplexCopier}) can route values through union/promotable writers
+   * without depending on {@code getField()}, which is undefined for holder-backed readers.
+   */
+  @Test
+  void testNullableUuidHolderReaderImplGetExtensionType() {
+    NullableUuidHolder holder = new NullableUuidHolder();
+    NullableUuidHolderReaderImpl reader = new NullableUuidHolderReaderImpl(holder);
+    assertEquals(UuidType.INSTANCE, reader.getExtensionType());
+  }
 }

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector.complex.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,6 +25,7 @@ import java.util.UUID;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.UuidVector;
 import org.apache.arrow.vector.compare.VectorEqualsVisitor;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -36,6 +38,7 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.extension.UuidType;
 import org.apache.arrow.vector.holders.DecimalHolder;
+import org.apache.arrow.vector.holders.NullableUuidHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -952,6 +955,55 @@ public class TestComplexCopier {
 
       // validate equals
       assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+    }
+  }
+
+  /**
+   * {@link ComplexCopier#copy} must work when the source reader is a holder-backed extension reader
+   * (here {@link NullableUuidHolderReaderImpl}). Holder readers do not implement {@link
+   * FieldReader#getField()}, so the copier obtains the extension {@link ArrowType} via {@code
+   * getExtensionType()} instead.
+   */
+  @Test
+  public void testCopyExtensionTypeFromNullableUuidHolderReader() {
+    try (UuidVector source = new UuidVector("v", allocator);
+        UuidVector target = new UuidVector("v", allocator)) {
+      UUID uuid = UUID.randomUUID();
+      source.setSafe(0, uuid);
+      source.setValueCount(1);
+
+      NullableUuidHolder holder = new NullableUuidHolder();
+      source.get(0, holder);
+
+      NullableUuidHolderReaderImpl reader = new NullableUuidHolderReaderImpl(holder);
+      UuidWriterImpl writer = new UuidWriterImpl(target);
+      writer.setPosition(0);
+
+      ComplexCopier.copy(reader, writer);
+      target.setValueCount(1);
+
+      assertEquals(uuid, target.getObject(0));
+    }
+  }
+
+  /**
+   * {@link ComplexCopier#copy} on a null-valued holder reader must take the not-set branch and
+   * write a null without invoking {@code getField()} or {@code readObject()}.
+   */
+  @Test
+  public void testCopyExtensionTypeFromNullValuedNullableUuidHolderReader() {
+    try (UuidVector target = new UuidVector("v", allocator)) {
+      NullableUuidHolder holder = new NullableUuidHolder();
+      holder.isSet = 0;
+
+      NullableUuidHolderReaderImpl reader = new NullableUuidHolderReaderImpl(holder);
+      UuidWriterImpl writer = new UuidWriterImpl(target);
+      writer.setPosition(0);
+
+      ComplexCopier.copy(reader, writer);
+      target.setValueCount(1);
+
+      assertTrue(target.isNull(0));
     }
   }
 }


### PR DESCRIPTION
### Background

`ComplexCopier.copy` does a deep-copy using a `FieldReader` from the source and a `FieldWriter` to write to the destination. On the read side in the `EXTENSIONTYPE` branch, it uses `reader.getField().getType()`  to get the `ArrowType` it needs to forward to `writer.writeExtension(value, type)`.  Vector-backed extension readers (UuidReaderImpl, VariantReaderImpl) override getField(), so this works. Holder readers (NullableUuidHolderReaderImpl, NullableVariantHolderReaderImpl) on the other hand do not. `AbstractFieldReader.getField` throws via `fail("getField")`, so any ComplexCopier.copy call with a holder reader as input fails.

As #1109 points out, overriding getField() on a holder reader is a simple fix but a holder does not have a notion of `Field`, the same way primitive (as opposed to extension) holder readers also do not have notion of `getField()` and the method is not overridden.

### What's Changed

`ComplexCopier` only needs the `ArrowType` here, not the whole Field. So this PR adds a narrower accessor for that:

```java
  default ArrowType getExtensionType() {
    return getField().getType();
  }
```

on `ExtensionReader`. The default delegates to `getField()`, so every existing vector-backed extension reader keeps working unchanged. Holder readers override `getExtensionType()` to return `holder.type()` — the `ExtensionHolder.type()` method added in #892 already returns the right ArrowType (UuidType.INSTANCE, VariantType.INSTANCE).

ComplexCopier call `reader.getExtensionType()` instead of `reader.getField().getType()`. The new method goes on ExtensionReader rather than AbstractFieldReader to sit next to the other extension-specific methods already there (read(ExtensionHolder), readObject(), isSet()). Adding a default method is this specific way is source- and binary-compatible.

Closes #1109 .
