### PR TITLE
GH-1134: add COLUMN_DEF support to JDBC getColumnns()

### DIFF
--- a/arrow-format/FlightSql.proto
+++ b/arrow-format/FlightSql.proto
@@ -1213,6 +1213,7 @@ message CommandGetDbSchemas {
  *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *  - ARROW:FLIGHT:SQL:COLUMN_DEF        - The default value for the column.
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {

--- a/arrow-format/FlightSql.proto
+++ b/arrow-format/FlightSql.proto
@@ -1681,6 +1681,7 @@ message ActionEndSavepointRequest {
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *    - ARROW:FLIGHT:SQL:COLUMN_DEF        - The default value for the column.
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
@@ -1707,6 +1708,7 @@ message CommandStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *    - ARROW:FLIGHT:SQL:COLUMN_DEF        - The default value for the column.
  *  - GetFlightInfo: execute the query.
  *  - DoPut: execute the query.
  */
@@ -1744,6 +1746,7 @@ message TicketStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *    - ARROW:FLIGHT:SQL:COLUMN_DEF        - The default value for the column.
  *
  *    If the schema is retrieved after parameter values have been bound with DoPut, then the server should account
  *    for the parameters when determining the schema.

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadata.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadata.java
@@ -1090,6 +1090,7 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     final VarCharVector tableSchemVector = (VarCharVector) currentRoot.getVector("TABLE_SCHEM");
     final VarCharVector tableNameVector = (VarCharVector) currentRoot.getVector("TABLE_NAME");
     final VarCharVector columnNameVector = (VarCharVector) currentRoot.getVector("COLUMN_NAME");
+    final VarCharVector columnDefVector = (VarCharVector) currentRoot.getVector("COLUMN_DEF");
     final IntVector dataTypeVector = (IntVector) currentRoot.getVector("DATA_TYPE");
     final VarCharVector typeNameVector = (VarCharVector) currentRoot.getVector("TYPE_NAME");
     final IntVector columnSizeVector = (IntVector) currentRoot.getVector("COLUMN_SIZE");
@@ -1129,6 +1130,11 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
       if (columnName != null) {
         columnNameVector.setSafe(insertIndex, columnName.getBytes(CHARSET));
+      }
+
+      final String columnDef = columnMetadata.getDefaultValue();
+      if (columnDef != null) {
+        columnDefVector.setSafe(insertIndex, columnDef.getBytes(CHARSET));
       }
 
       dataTypeVector.setSafe(insertIndex, SqlTypes.getSqlTypeIdFromArrowType(fieldType));

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadataTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadataTest.java
@@ -308,6 +308,7 @@ public class ArrowDatabaseMetadataTest {
     List<Integer> expectedGetColumnsColumnSize = Arrays.asList(5, 29, 10);
     List<Integer> expectedGetColumnsDecimalDigits = Arrays.asList(2, 9, 0);
     List<String> expectedGetColumnsIsNullable = Arrays.asList("YES", "YES", "NO");
+    List<String> expectedGetColumnsDefaultValue = Arrays.asList("123.45", null, "1");
     EXPECTED_GET_COLUMNS_RESULTS =
         range(0, ROW_COUNT * 3)
             .mapToObj(
@@ -325,7 +326,7 @@ public class ArrowDatabaseMetadataTest {
                       expectedGetColumnsRadix.get(i % 3),
                       !Objects.equals(expectedGetColumnsIsNullable.get(i % 3), "NO") ? 1 : 0,
                       format("column description #%d", (i % 3) + 1),
-                      null,
+                      expectedGetColumnsDefaultValue.get(i % 3),
                       null,
                       null,
                       null,
@@ -430,6 +431,7 @@ public class ArrowDatabaseMetadataTest {
                         null,
                         new FlightSqlColumnMetadata.Builder()
                             .remarks("column description #1")
+                            .defaultValue("123.45")
                             .build()
                             .getMetadataMap()),
                     null);
@@ -454,6 +456,7 @@ public class ArrowDatabaseMetadataTest {
                         null,
                         new FlightSqlColumnMetadata.Builder()
                             .remarks("column description #3")
+                            .defaultValue("1")
                             .build()
                             .getMetadataMap()),
                     null);

--- a/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlColumnMetadata.java
+++ b/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlColumnMetadata.java
@@ -49,6 +49,7 @@ public class FlightSqlColumnMetadata {
   private static final String TYPE_NAME = "ARROW:FLIGHT:SQL:TYPE_NAME";
   private static final String PRECISION = "ARROW:FLIGHT:SQL:PRECISION";
   private static final String SCALE = "ARROW:FLIGHT:SQL:SCALE";
+  private static final String DEFAULT_VALUE = "ARROW:FLIGHT:SQL:COLUMN_DEF";
   private static final String IS_AUTO_INCREMENT = "ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT";
   private static final String IS_CASE_SENSITIVE = "ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE";
   private static final String IS_READ_ONLY = "ARROW:FLIGHT:SQL:IS_READ_ONLY";
@@ -136,6 +137,15 @@ public class FlightSqlColumnMetadata {
     }
 
     return Integer.valueOf(value);
+  }
+
+  /**
+   * Returns the default value of the column.
+   *
+   * @return The default value of the column.
+   */
+  public String getDefaultValue() {
+    return metadataMap.get(DEFAULT_VALUE);
   }
 
   /**
@@ -275,6 +285,17 @@ public class FlightSqlColumnMetadata {
      */
     public Builder scale(int scale) {
       metadataMap.put(SCALE, Integer.toString(scale));
+      return this;
+    }
+
+    /**
+     * Sets the column's default value.
+     *
+     * @param defaultValue The column's default value.
+     * @return This builder.
+     */
+    public Builder defaultValue(String defaultValue) {
+      metadataMap.put(DEFAULT_VALUE, defaultValue);
       return this;
     }
 


### PR DESCRIPTION
## What's Changed

Updates the `FlightSqlColumnMetadata` to contain the JDBC `COLUMN_DEF` field alongside getters/setters.  Following exiting naming format.

Updates `ArrowDatabaseMetadata` to write to the pre-existing `COLUMN_DEF` vector as part of the `getColumns()` code paths.

Updates test(s) in `ArrowDatabaseMetadataTest` to test default value behavior.

Closes #1134.
