### PR TITLE
MINOR: Fix Gandiva JNI build against Arrow C++ 24.0.0

### DIFF
--- a/.env
+++ b/.env
@@ -53,4 +53,4 @@ MAVEN=3.9.9
 # Versions for various dependencies used to build artifacts
 # Keep in sync with apache/arrow
 ARROW_REPO_ROOT=./arrow
-VCPKG="4334d8b4c8916018600212ab4dd4bbdc343065d1"    # 2025.09.17 Release
+VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release

--- a/ci/scripts/jni_manylinux_build.sh
+++ b/ci/scripts/jni_manylinux_build.sh
@@ -74,10 +74,7 @@ cmake \
   -S "${arrow_dir}/cpp" \
   -B "${build_dir}/cpp" \
   --preset=ninja-release-jni-linux \
-  -DCMAKE_INSTALL_PREFIX="${install_dir}" \
-  -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
-  -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
-  -Dxsimd_SOURCE=BUNDLED
+  -DCMAKE_INSTALL_PREFIX="${install_dir}"
 cmake --build "${build_dir}/cpp"
 cmake --install "${build_dir}/cpp"
 github_actions_group_end

--- a/ci/scripts/jni_manylinux_build.sh
+++ b/ci/scripts/jni_manylinux_build.sh
@@ -68,6 +68,9 @@ export ARROW_PARQUET=ON
 
 export AWS_EC2_METADATA_DISABLED=TRUE
 
+# Arrow C++ 24.0.0 requires xsimd >= 14.0.0 which may not be pre-installed in the base image
+"${VCPKG_ROOT}/vcpkg" install "xsimd:${VCPKG_TARGET_TRIPLET}"
+
 install_dir="${build_dir}/cpp-install"
 
 cmake \

--- a/ci/scripts/jni_manylinux_build.sh
+++ b/ci/scripts/jni_manylinux_build.sh
@@ -68,9 +68,6 @@ export ARROW_PARQUET=ON
 
 export AWS_EC2_METADATA_DISABLED=TRUE
 
-# Arrow C++ 24.0.0 requires xsimd >= 14.0.0 which may not be pre-installed in the base image
-"${VCPKG_ROOT}/vcpkg" install "xsimd:${VCPKG_TARGET_TRIPLET}"
-
 install_dir="${build_dir}/cpp-install"
 
 cmake \
@@ -79,7 +76,8 @@ cmake \
   --preset=ninja-release-jni-linux \
   -DCMAKE_INSTALL_PREFIX="${install_dir}" \
   -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
-  -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}"
+  -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
+  -Dxsimd_SOURCE=BUNDLED
 cmake --build "${build_dir}/cpp"
 cmake --install "${build_dir}/cpp"
 github_actions_group_end

--- a/ci/scripts/jni_manylinux_build.sh
+++ b/ci/scripts/jni_manylinux_build.sh
@@ -77,7 +77,9 @@ cmake \
   -S "${arrow_dir}/cpp" \
   -B "${build_dir}/cpp" \
   --preset=ninja-release-jni-linux \
-  -DCMAKE_INSTALL_PREFIX="${install_dir}"
+  -DCMAKE_INSTALL_PREFIX="${install_dir}" \
+  -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+  -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}"
 cmake --build "${build_dir}/cpp"
 cmake --install "${build_dir}/cpp"
 github_actions_group_end

--- a/compose.yaml
+++ b/compose.yaml
@@ -109,5 +109,6 @@ services:
       ARROW_JAVA_CDATA: "ON"
       CCACHE_DIR: "/ccache"
     command:
-      ["git config --global --add safe.directory /arrow-java && \
+      ["/bin/bash", "-c",
+       "git config --global --add safe.directory /arrow-java &&
         /arrow-java/ci/scripts/jni_manylinux_build.sh /arrow-java /arrow /build/java /arrow-java/jni"]

--- a/gandiva/src/main/cpp/jni_common.cc
+++ b/gandiva/src/main/cpp/jni_common.cc
@@ -221,7 +221,7 @@ DataTypePtr ProtoTypeToDataType(const gandiva::types::ExtGandivaType& ext_type) 
       return arrow::date64();
     case gandiva::types::DECIMAL:
       // TODO: error handling
-      return arrow::decimal(ext_type.precision(), ext_type.scale());
+      return arrow::decimal128(ext_type.precision(), ext_type.scale());
     case gandiva::types::TIME32:
       return ProtoTypeToTime32(ext_type);
     case gandiva::types::TIME64:


### PR DESCRIPTION
Arrow C++ 24.0.0 introduced two breaking changes for the JNI build:

1. `arrow::decimal()` was removed; replaced with `arrow::decimal128()` in the Gandiva JNI source.

2. xsimd >= 14.0.0 is now a required dependency. The Docker image's vcpkg registry only ships xsimd 13.2.0, so the Linux JNI CMake configuration was failing. Fixed by passing `xsimd_SOURCE=BUNDLED` to the Arrow C++ CMake configure step so Arrow downloads and uses xsimd 14.0.0 directly, and by passing the vcpkg toolchain file to the Arrow C++ configure step so other vcpkg-managed dependencies are still resolved correctly.