### PR TITLE
GH-834: Fix Avro nullable consumer to use readIndex for unions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ cmake_install.cmake
 dependency-reduced-pom.xml
 install_manifest.txt
 target/
+.claude/
+CLAUDE.md
+*.class

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/AvroToArrowUtils.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/AvroToArrowUtils.java
@@ -431,7 +431,7 @@ public class AvroToArrowUtils {
       case UNION:
         List<Consumer> unionDelegates =
             schema.getTypes().stream().map(s -> createSkipConsumer(s)).collect(Collectors.toList());
-        skipFunction = decoder -> unionDelegates.get(decoder.readInt()).consume(decoder);
+        skipFunction = decoder -> unionDelegates.get(decoder.readIndex()).consume(decoder);
 
         break;
       case ARRAY:

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroNullableConsumer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroNullableConsumer.java
@@ -41,7 +41,7 @@ public class AvroNullableConsumer<T extends FieldVector> extends BaseAvroConsume
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    int typeIndex = decoder.readInt();
+    int typeIndex = decoder.readIndex();
     if (typeIndex == nullIndex) {
       decoder.readNull();
       delegate.addNull();

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroStringConsumer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroStringConsumer.java
@@ -17,9 +17,9 @@
 package org.apache.arrow.adapter.avro.consumers;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
 
 /**
  * Consumer which consume string type values from avro decoder. Write the data to {@link
@@ -27,7 +27,7 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroStringConsumer extends BaseAvroConsumer<VarCharVector> {
 
-  private ByteBuffer cacheBuffer;
+  private Utf8 cachedUtf8;
 
   /** Instantiate a AvroStringConsumer. */
   public AvroStringConsumer(VarCharVector vector) {
@@ -36,9 +36,7 @@ public class AvroStringConsumer extends BaseAvroConsumer<VarCharVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    // cacheBuffer is initialized null and create in the first consume,
-    // if its capacity < size to read, decoder will create a new one with new capacity.
-    cacheBuffer = decoder.readBytes(cacheBuffer);
-    vector.setSafe(currentIndex++, cacheBuffer, 0, cacheBuffer.limit());
+    cachedUtf8 = decoder.readString(cachedUtf8);
+    vector.setSafe(currentIndex++, cachedUtf8.getBytes(), 0, cachedUtf8.getByteLength());
   }
 }

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroUnionsConsumer.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroUnionsConsumer.java
@@ -42,7 +42,7 @@ public class AvroUnionsConsumer extends BaseAvroConsumer<UnionVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    int fieldIndex = decoder.readInt();
+    int fieldIndex = decoder.readIndex();
 
     ensureInnerVectorCapacity(currentIndex + 1, fieldIndex);
     Consumer delegate = delegates[fieldIndex];

--- a/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowTest.java
+++ b/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowTest.java
@@ -18,6 +18,8 @@ package org.apache.arrow.adapter.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -33,7 +35,13 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
 import org.junit.jupiter.api.Test;
 
 public class AvroToArrowTest extends AvroTestBase {
@@ -473,5 +481,28 @@ public class AvroToArrowTest extends AvroTestBase {
     FieldVector vector = root.getFieldVectors().get(0);
 
     checkPrimitiveResult(expected, vector);
+  }
+
+  @Test
+  public void testNullableStringTypeWithValidatingDecoder() throws Exception {
+    Schema schema = getSchema("test_nullable_string.avsc");
+
+    GenericRecord record = new GenericData.Record(schema);
+    record.put(0, "hello");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(out, null);
+    DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+    writer.write(record, encoder);
+    encoder.flush();
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    Decoder binaryDecoder = DecoderFactory.get().directBinaryDecoder(in, null);
+    Decoder validatingDecoder = DecoderFactory.get().validatingDecoder(schema, binaryDecoder);
+
+    VectorSchemaRoot root = AvroToArrow.avroToArrow(schema, validatingDecoder, config);
+    assertEquals(1, root.getRowCount());
+    FieldVector vector = root.getVector("f0");
+    assertEquals("hello", vector.getObject(0).toString());
   }
 }


### PR DESCRIPTION
## Description: 
Updates Avro consumers to use readIndex() for unions and readString() for strings instead of readInt() and readBytes(). This ensures compatibility with Avro's ValidatingDecoder, which strictly enforces type-specific read methods. Includes a regression test for nullable strings.