### PR TITLE
GH-1190: Reserve view slots for empty view vector values

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -1405,7 +1405,8 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector
   }
 
   protected final void handleSafe(int index, int dataLength) {
-    final long targetCapacity = roundUpToMultipleOf16((long) index * ELEMENT_SIZE + dataLength);
+    // The view buffer stores one fixed-width view per value; payload bytes are allocated separately.
+    final long targetCapacity = roundUpToMultipleOf16(((long) index + 1) * ELEMENT_SIZE);
     if (viewBuffer.capacity() < targetCapacity) {
       reallocViewBuffer(targetCapacity);
     }

--- a/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -1405,7 +1405,8 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector
   }
 
   protected final void handleSafe(int index, int dataLength) {
-    // The view buffer stores one fixed-width view per value; payload bytes are allocated separately.
+    // The view buffer stores one fixed-width view per value; payload bytes are allocated
+    // separately.
     final long targetCapacity = roundUpToMultipleOf16(((long) index + 1) * ELEMENT_SIZE);
     if (viewBuffer.capacity() < targetCapacity) {
       reallocViewBuffer(targetCapacity);

--- a/vector/src/test/java/org/apache/arrow/vector/TestVariableWidthViewVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestVariableWidthViewVector.java
@@ -540,6 +540,26 @@ public class TestVariableWidthViewVector {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource({"vectorCreatorProvider"})
+  public void testSetSafeEmptyValueAtViewBufferBoundary(
+      Function<BufferAllocator, BaseVariableWidthViewVector> vectorCreator) {
+    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator)) {
+      final byte[] emptyValue = new byte[0];
+      vector.allocateNew();
+      final int valueCapacity = vector.getValueCapacity();
+
+      for (int i = 0; i <= valueCapacity; i++) {
+        vector.setSafe(i, emptyValue);
+      }
+
+      vector.setValueCount(valueCapacity + 1);
+      assertTrue(vector.getValueCapacity() > valueCapacity);
+      assertEquals(0, vector.getValueLength(valueCapacity));
+      assertArrayEquals(emptyValue, vector.get(valueCapacity));
+    }
+  }
+
   @Test
   public void testNullableVarType1() {
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestVariableWidthViewVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestVariableWidthViewVector.java
@@ -560,6 +560,40 @@ public class TestVariableWidthViewVector {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource({"vectorCreatorProvider"})
+  public void testSetValueCountFillsEmptiesAtViewBufferBoundary(
+      Function<BufferAllocator, BaseVariableWidthViewVector> vectorCreator) {
+    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator)) {
+      vector.allocateNew();
+      final int valueCapacity = vector.getValueCapacity();
+
+      vector.setSafe(valueCapacity - 1, "x".getBytes(StandardCharsets.UTF_8));
+      vector.setValueCount(valueCapacity + 1);
+
+      assertTrue(vector.getValueCapacity() > valueCapacity);
+      assertTrue(vector.isNull(valueCapacity));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource({"vectorCreatorProvider"})
+  public void testSetNullAtViewBufferBoundary(
+      Function<BufferAllocator, BaseVariableWidthViewVector> vectorCreator) {
+    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator)) {
+      vector.allocateNew();
+      final int valueCapacity = vector.getValueCapacity();
+
+      for (int i = 0; i <= valueCapacity; i++) {
+        vector.setNull(i);
+      }
+      vector.setValueCount(valueCapacity + 1);
+
+      assertTrue(vector.getValueCapacity() > valueCapacity);
+      assertTrue(vector.isNull(valueCapacity));
+    }
+  }
+
   @Test
   public void testNullableVarType1() {
 


### PR DESCRIPTION
## What's Changed

Fixes `BaseVariableWidthViewVector.handleSafe` so `setSafe` reserves a full 16-byte view slot for the target index even when the value length is zero.

Adds coverage for empty values written through the first view-buffer boundary for both `ViewVarCharVector` and `ViewVarBinaryVector`.

## Tests

- `mvn -pl vector -am -Dtest=TestVariableWidthViewVector#testSetSafeEmptyValueAtViewBufferBoundary -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl vector -am -Dtest=TestVariableWidthViewVector -Dsurefire.failIfNoSpecifiedTests=false test`

Closes #1190.
