### PR TITLE
MINOR: Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,9 @@ name: Dev
 
 on:
   pull_request: {}
-  push: {}
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches

## What's Changed

Please fill in a description of the changes here.

**This contains breaking changes.**  <!-- Remove this line if there are no breaking changes. -->

Closes #NNN.
