### PR TITLE
GH-1194: Preserve empty list offset buffers

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -305,10 +305,12 @@ public class LargeListVector extends BaseValueVector
 
   /** Set the reader and writer indexes for the inner buffers. */
   private void setReaderAndWriterIndex() {
+    final long requiredOffsetBufferCapacity = (long) (valueCount + 1) * OFFSET_WIDTH;
     validityBuffer.readerIndex(0);
     offsetBuffer.readerIndex(0);
     if (valueCount == 0) {
       validityBuffer.writerIndex(0);
+      ensureEmptyOffsetBufferCapacity(requiredOffsetBufferCapacity);
     } else {
       validityBuffer.writerIndex(BitVectorHelper.getValidityBufferSizeFromCount(valueCount));
     }
@@ -316,7 +318,28 @@ public class LargeListVector extends BaseValueVector
     // Both are set to 0 means 0 bytes are written to the IPC stream which will crash IPC readers
     // in other libraries. According to Arrow spec, we should still output the offset buffer which
     // is [0].
-    offsetBuffer.writerIndex((long) (valueCount + 1) * OFFSET_WIDTH);
+    offsetBuffer.writerIndex(requiredOffsetBufferCapacity);
+  }
+
+  private void ensureEmptyOffsetBufferCapacity(long requiredCapacity) {
+    if (offsetBuffer.capacity() >= requiredCapacity) {
+      return;
+    }
+    long previousOffsetAllocationSizeInBytes = offsetAllocationSizeInBytes;
+    ArrowBuf oldOffsetBuffer = offsetBuffer;
+    offsetBuffer = allocateOffsetBuffer(requiredCapacity);
+    final long bytesToCopy = Math.min(oldOffsetBuffer.capacity(), requiredCapacity);
+    offsetBuffer.setBytes(0, oldOffsetBuffer, 0, bytesToCopy);
+
+    final int copiedOffsets = (int) (bytesToCopy / OFFSET_WIDTH);
+    final int requiredOffsets = (int) (requiredCapacity / OFFSET_WIDTH);
+    final long lastCopiedOffset =
+        copiedOffsets == 0 ? 0 : offsetBuffer.getLong((long) (copiedOffsets - 1) * OFFSET_WIDTH);
+    for (int i = copiedOffsets; i < requiredOffsets; i++) {
+      offsetBuffer.setLong((long) i * OFFSET_WIDTH, lastCopiedOffset);
+    }
+    offsetAllocationSizeInBytes = previousOffsetAllocationSizeInBytes;
+    oldOffsetBuffer.getReferenceManager().release();
   }
 
   /**
@@ -674,24 +697,30 @@ public class LargeListVector extends BaseValueVector
           startIndex,
           length,
           valueCount);
-      final long startPoint = offsetBuffer.getLong((long) startIndex * OFFSET_WIDTH);
-      final long sliceLength =
-          offsetBuffer.getLong((long) (startIndex + length) * OFFSET_WIDTH) - startPoint;
       to.clear();
-      to.offsetBuffer = to.allocateOffsetBuffer((length + 1) * OFFSET_WIDTH);
-      /* splitAndTransfer offset buffer */
-      for (int i = 0; i < length + 1; i++) {
-        final long relativeOffset =
-            offsetBuffer.getLong((long) (startIndex + i) * OFFSET_WIDTH) - startPoint;
-        to.offsetBuffer.setLong((long) i * OFFSET_WIDTH, relativeOffset);
+      if (length > 0) {
+        final long startPoint = offsetBuffer.getLong((long) startIndex * OFFSET_WIDTH);
+        final long sliceLength =
+            offsetBuffer.getLong((long) (startIndex + length) * OFFSET_WIDTH) - startPoint;
+        to.offsetBuffer = to.allocateOffsetBuffer((length + 1) * OFFSET_WIDTH);
+        /* splitAndTransfer offset buffer */
+        for (int i = 0; i < length + 1; i++) {
+          final long relativeOffset =
+              offsetBuffer.getLong((long) (startIndex + i) * OFFSET_WIDTH) - startPoint;
+          to.offsetBuffer.setLong((long) i * OFFSET_WIDTH, relativeOffset);
+        }
+        /* splitAndTransfer validity buffer */
+        splitAndTransferValidityBuffer(startIndex, length, to);
+        /* splitAndTransfer data buffer */
+        dataTransferPair.splitAndTransfer(
+            checkedCastToInt(startPoint), checkedCastToInt(sliceLength));
+        to.lastSet = length - 1;
+        to.setValueCount(length);
+      } else {
+        to.ensureEmptyOffsetBufferCapacity(OFFSET_WIDTH);
+        dataTransferPair.splitAndTransfer(0, 0);
+        to.setValueCount(0);
       }
-      /* splitAndTransfer validity buffer */
-      splitAndTransferValidityBuffer(startIndex, length, to);
-      /* splitAndTransfer data buffer */
-      dataTransferPair.splitAndTransfer(
-          checkedCastToInt(startPoint), checkedCastToInt(sliceLength));
-      to.lastSet = length - 1;
-      to.setValueCount(length);
     }
 
     @Override

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -263,10 +263,12 @@ public class ListVector extends BaseRepeatedValueVector
 
   /** Set the reader and writer indexes for the inner buffers. */
   private void setReaderAndWriterIndex() {
+    final long requiredOffsetBufferCapacity = (long) (valueCount + 1) * OFFSET_WIDTH;
     validityBuffer.readerIndex(0);
     offsetBuffer.readerIndex(0);
     if (valueCount == 0) {
       validityBuffer.writerIndex(0);
+      ensureEmptyOffsetBufferCapacity(requiredOffsetBufferCapacity);
     } else {
       validityBuffer.writerIndex(BitVectorHelper.getValidityBufferSizeFromCount(valueCount));
     }
@@ -274,7 +276,28 @@ public class ListVector extends BaseRepeatedValueVector
     // Both are set to 0 means 0 bytes are written to the IPC stream which will crash IPC readers
     // in other libraries. According to Arrow spec, we should still output the offset buffer which
     // is [0].
-    offsetBuffer.writerIndex((long) (valueCount + 1) * OFFSET_WIDTH);
+    offsetBuffer.writerIndex(requiredOffsetBufferCapacity);
+  }
+
+  private void ensureEmptyOffsetBufferCapacity(long requiredCapacity) {
+    if (offsetBuffer.capacity() >= requiredCapacity) {
+      return;
+    }
+    long previousOffsetAllocationSizeInBytes = offsetAllocationSizeInBytes;
+    ArrowBuf oldOffsetBuffer = offsetBuffer;
+    offsetBuffer = allocateOffsetBuffer(requiredCapacity);
+    final long bytesToCopy = Math.min(oldOffsetBuffer.capacity(), requiredCapacity);
+    offsetBuffer.setBytes(0, oldOffsetBuffer, 0, bytesToCopy);
+
+    final int copiedOffsets = (int) (bytesToCopy / OFFSET_WIDTH);
+    final int requiredOffsets = (int) (requiredCapacity / OFFSET_WIDTH);
+    final int lastCopiedOffset =
+        copiedOffsets == 0 ? 0 : offsetBuffer.getInt((copiedOffsets - 1) * OFFSET_WIDTH);
+    for (int i = copiedOffsets; i < requiredOffsets; i++) {
+      offsetBuffer.setInt(i * OFFSET_WIDTH, lastCopiedOffset);
+    }
+    offsetAllocationSizeInBytes = previousOffsetAllocationSizeInBytes;
+    oldOffsetBuffer.getReferenceManager().release();
   }
 
   /**
@@ -572,6 +595,10 @@ public class ListVector extends BaseRepeatedValueVector
         dataTransferPair.splitAndTransfer(startPoint, sliceLength);
         to.lastSet = length - 1;
         to.setValueCount(length);
+      } else {
+        to.ensureEmptyOffsetBufferCapacity(OFFSET_WIDTH);
+        dataTransferPair.splitAndTransfer(0, 0);
+        to.setValueCount(0);
       }
     }
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -1102,22 +1102,87 @@ public class TestLargeListVector {
 
   @Test
   public void testEmptyLargeListOffsetBuffer() {
-    // Test that LargeListVector has correct readableBytes after allocation.
-    // According to Arrow spec, offset buffer must have N+1 entries.
-    // Even when N=0, it should contain [0].
     try (LargeListVector list = LargeListVector.empty("list", allocator)) {
       list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
       list.allocateNew();
       list.setValueCount(0);
 
-      List<ArrowBuf> buffers = list.getFieldBuffers();
-      assertTrue(
-          buffers.get(1).readableBytes() >= LargeListVector.OFFSET_WIDTH,
-          "Offset buffer should have at least "
-              + LargeListVector.OFFSET_WIDTH
-              + " bytes for offset[0]");
-      assertEquals(0L, list.getOffsetBuffer().getLong(0));
+      assertEmptyLargeListOffsetBuffer(list);
     }
+  }
+
+  @Test
+  public void testUnallocatedEmptyLargeListOffsetBuffer() {
+    try (LargeListVector list = LargeListVector.empty("list", allocator)) {
+      list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      list.setValueCount(0);
+
+      assertEmptyLargeListOffsetBuffer(list);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyLargeListOffsetBuffer() {
+    try (LargeListVector source = LargeListVector.empty("source", allocator);
+        LargeListVector target = LargeListVector.empty("target", allocator)) {
+      source.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      target.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      source.allocateNew();
+      source.setValueCount(0);
+
+      TransferPair transferPair = source.makeTransferPair(target);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertEmptyLargeListOffsetBuffer(target);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyLargeListAllocatesOffsetBuffer() {
+    try (LargeListVector fromVector = LargeListVector.empty("fromVector", allocator);
+        LargeListVector toVector = LargeListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyLargeListOffsetBuffer(toVector);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyNestedLargeListAllocatesOffsetBuffers() {
+    try (LargeListVector fromVector = LargeListVector.empty("fromVector", allocator);
+        LargeListVector toVector = LargeListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.LARGELIST.getType()));
+      LargeListVector childVector = (LargeListVector) fromVector.getDataVector();
+      childVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyLargeListOffsetBuffer(toVector);
+      assertAllocatedEmptyLargeListOffsetBuffer((LargeListVector) toVector.getDataVector());
+    }
+  }
+
+  private ArrowBuf assertEmptyLargeListOffsetBuffer(LargeListVector list) {
+    List<ArrowBuf> buffers = list.getFieldBuffers();
+    ArrowBuf offsetBuffer = buffers.get(1);
+    assertEquals(LargeListVector.OFFSET_WIDTH, offsetBuffer.readableBytes());
+    assertTrue(offsetBuffer.capacity() >= LargeListVector.OFFSET_WIDTH);
+    assertEquals(0L, offsetBuffer.getLong(0));
+    return offsetBuffer;
+  }
+
+  private void assertAllocatedEmptyLargeListOffsetBuffer(LargeListVector list) {
+    ArrowBuf offsetBuffer = list.getOffsetBuffer();
+    assertTrue(offsetBuffer.capacity() >= LargeListVector.OFFSET_WIDTH);
+    assertEquals(0L, offsetBuffer.getLong(0));
   }
 
   private void writeIntValues(UnionLargeListWriter writer, int[] values) {

--- a/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -1381,22 +1381,87 @@ public class TestListVector {
 
   @Test
   public void testEmptyListOffsetBuffer() {
-    // Test that ListVector has correct readableBytes after allocation.
-    // According to Arrow spec, offset buffer must have N+1 entries.
-    // Even when N=0, it should contain [0].
     try (ListVector list = ListVector.empty("list", allocator)) {
       list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
       list.allocateNew();
       list.setValueCount(0);
 
-      List<ArrowBuf> buffers = list.getFieldBuffers();
-      assertTrue(
-          buffers.get(1).readableBytes() >= BaseRepeatedValueVector.OFFSET_WIDTH,
-          "Offset buffer should have at least "
-              + BaseRepeatedValueVector.OFFSET_WIDTH
-              + " bytes for offset[0]");
-      assertEquals(0, list.getOffsetBuffer().getInt(0));
+      assertEmptyListOffsetBuffer(list);
     }
+  }
+
+  @Test
+  public void testUnallocatedEmptyListOffsetBuffer() {
+    try (ListVector list = ListVector.empty("list", allocator)) {
+      list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      list.setValueCount(0);
+
+      assertEmptyListOffsetBuffer(list);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyListOffsetBuffer() {
+    try (ListVector source = ListVector.empty("source", allocator);
+        ListVector target = ListVector.empty("target", allocator)) {
+      source.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      target.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      source.allocateNew();
+      source.setValueCount(0);
+
+      TransferPair transferPair = source.makeTransferPair(target);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertEmptyListOffsetBuffer(target);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyListAllocatesOffsetBuffer() {
+    try (ListVector fromVector = ListVector.empty("fromVector", allocator);
+        ListVector toVector = ListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyListOffsetBuffer(toVector);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyNestedListAllocatesOffsetBuffers() {
+    try (ListVector fromVector = ListVector.empty("fromVector", allocator);
+        ListVector toVector = ListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.LIST.getType()));
+      ListVector childVector = (ListVector) fromVector.getDataVector();
+      childVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyListOffsetBuffer(toVector);
+      assertAllocatedEmptyListOffsetBuffer((ListVector) toVector.getDataVector());
+    }
+  }
+
+  private ArrowBuf assertEmptyListOffsetBuffer(ListVector list) {
+    List<ArrowBuf> buffers = list.getFieldBuffers();
+    ArrowBuf offsetBuffer = buffers.get(1);
+    assertEquals(BaseRepeatedValueVector.OFFSET_WIDTH, offsetBuffer.readableBytes());
+    assertTrue(offsetBuffer.capacity() >= BaseRepeatedValueVector.OFFSET_WIDTH);
+    assertEquals(0, offsetBuffer.getInt(0));
+    return offsetBuffer;
+  }
+
+  private void assertAllocatedEmptyListOffsetBuffer(ListVector list) {
+    ArrowBuf offsetBuffer = list.getOffsetBuffer();
+    assertTrue(offsetBuffer.capacity() >= BaseRepeatedValueVector.OFFSET_WIDTH);
+    assertEquals(0, offsetBuffer.getInt(0));
   }
 
   private void writeIntValues(UnionListWriter writer, int[] values) {

--- a/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
@@ -28,10 +28,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.LargeListViewVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
@@ -111,13 +114,16 @@ public class TestSplitAndTransfer {
   @Test
   public void testWithEmptyVector() {
     // MapVector use TransferImpl from ListVector
-    ListVector listVector = ListVector.empty("", allocator);
-    TransferPair transferPair = listVector.getTransferPair(allocator);
-    transferPair.splitAndTransfer(0, 0);
-    assertEquals(0, transferPair.getTo().getValueCount());
+    try (ListVector listVector = ListVector.empty("", allocator)) {
+      TransferPair transferPair = listVector.getTransferPair(allocator);
+      try (ValueVector toVector = transferPair.getTo()) {
+        transferPair.splitAndTransfer(0, 0);
+        assertEquals(0, toVector.getValueCount());
+      }
+    }
     // BaseFixedWidthVector
     IntVector intVector = new IntVector("", allocator);
-    transferPair = intVector.getTransferPair(allocator);
+    TransferPair transferPair = intVector.getTransferPair(allocator);
     transferPair.splitAndTransfer(0, 0);
     assertEquals(0, transferPair.getTo().getValueCount());
     // BaseVariableWidthVector
@@ -899,6 +905,29 @@ public class TestSplitAndTransfer {
   }
 
   @Test
+  public void testLargeListVectorZeroStartIndexAndLength() {
+    try (final LargeListVector listVector = LargeListVector.empty("largelist", allocator);
+        final LargeListVector newListVector = LargeListVector.empty("newList", allocator)) {
+
+      listVector.allocateNew();
+      final int valueCount = 0;
+      listVector.setValueCount(valueCount);
+
+      final TransferPair tp = listVector.makeTransferPair(newListVector);
+
+      tp.splitAndTransfer(0, 0);
+      assertEquals(valueCount, newListVector.getValueCount());
+      List<ArrowBuf> buffers = newListVector.getFieldBuffers();
+      ArrowBuf offsetBuffer = buffers.get(1);
+      assertEquals(LargeListVector.OFFSET_WIDTH, offsetBuffer.readableBytes());
+      assertTrue(offsetBuffer.capacity() >= LargeListVector.OFFSET_WIDTH);
+      assertEquals(0L, offsetBuffer.getLong(0));
+
+      newListVector.clear();
+    }
+  }
+
+  @Test
   public void testListVectorZeroStartIndexAndLength() {
     try (final ListVector listVector = ListVector.empty("list", allocator);
         final ListVector newListVector = ListVector.empty("newList", allocator)) {
@@ -911,6 +940,11 @@ public class TestSplitAndTransfer {
 
       tp.splitAndTransfer(0, 0);
       assertEquals(valueCount, newListVector.getValueCount());
+      List<ArrowBuf> buffers = newListVector.getFieldBuffers();
+      ArrowBuf offsetBuffer = buffers.get(1);
+      assertEquals(BaseRepeatedValueVector.OFFSET_WIDTH, offsetBuffer.readableBytes());
+      assertTrue(offsetBuffer.capacity() >= BaseRepeatedValueVector.OFFSET_WIDTH);
+      assertEquals(0, offsetBuffer.getInt(0));
 
       newListVector.clear();
     }


### PR DESCRIPTION
## What's Changed

Preserve the required one-entry offset buffer for empty `ListVector` and `LargeListVector` instances when setting value count and when splitting/transferring zero values. This keeps empty list vectors aligned with the Arrow offset-buffer invariant and avoids exposing buffers whose writer index exceeds capacity.

Adds regression coverage for allocated, unallocated, split-and-transfer, and nested empty list vectors.

Closes #1194.

Tests:
- `mvn -pl vector -am -P=-error-prone -Dmaven.gitcommitid.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestSplitAndTransfer,TestListVector,TestLargeListVector test`
- `mvn -P=-error-prone -Dmaven.gitcommitid.skip=true test`