### PR TITLE
GH-1236: fix out-of-slice read in ArrowFlightJdbcArray.checkBoundaries

### DIFF
--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArray.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArray.java
@@ -90,7 +90,7 @@ public class ArrowFlightJdbcArray implements Array {
   }
 
   private void checkBoundaries(long index, int count) {
-    if (index < 0 || index + count > this.startOffset + this.valuesCount) {
+    if (index < 0 || index + count > this.valuesCount) {
       throw new ArrayIndexOutOfBoundsException();
     }
   }

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArrayTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArrayTest.java
@@ -106,6 +106,20 @@ public class ArrowFlightJdbcArrayTest {
   }
 
   @Test
+  public void testShouldGetArrayWithOffsetsNotReadPastEndOfSlice() throws SQLException {
+    // Array covering elements 5, 6 and 7 of the underlying vector.
+    ArrowFlightJdbcArray arrowFlightJdbcArray = new ArrowFlightJdbcArray(dataVector, 5, 3);
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> arrowFlightJdbcArray.getArray(1, 3));
+  }
+
+  @Test
+  public void testShouldGetResultSetWithOffsetsNotReadPastEndOfSlice() throws SQLException {
+    ArrowFlightJdbcArray arrowFlightJdbcArray = new ArrowFlightJdbcArray(dataVector, 5, 3);
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> arrowFlightJdbcArray.getResultSet(1, 3));
+  }
+
+  @Test
   public void testShouldGetArrayWithMapNotBeSupported() throws SQLException {
     ArrowFlightJdbcArray arrowFlightJdbcArray =
         new ArrowFlightJdbcArray(dataVector, 0, dataVector.getValueCount());


### PR DESCRIPTION
## What's Changed

checkBoundaries validates the caller index against startOffset + valuesCount, but index is relative to the start of the array and both call sites add startOffset to it only after the check, so the accepted range is too long by exactly startOffset elements. getArray and getResultSet then read that far past the end of the row's slice. AbstractArrowFlightJdbcListVectorAccessor constructs these from the offsets of the list element being read, so any row of a list column not starting at child offset 0 hands back values belonging to neighbouring rows of the shared child vector, and past the child's valueCount whatever is in allocated-but-unwritten memory. The bound belongs on the relative index, so it is compared against valuesCount instead; that is the same expression as today when startOffset is 0, which is why the existing tests all pass unchanged and only the offset case gets tighter. Added a regression test for each of the two entry points, both of which fail on main.

Closes #1236.