### PR TITLE
GH-1246: validate decimal byte length before writing in setBigEndian

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
@@ -208,6 +208,14 @@ public final class Decimal256Vector extends BaseFixedWidthVector
     BitVectorHelper.setBit(validityBuffer, index);
     final int length = value.length;
 
+    // Reject an oversized value before any bytes are written. The little-endian path below
+    // copies all `length` bytes into the fixed TYPE_WIDTH slot with unchecked native writes,
+    // so validating after the copy would leave adjacent memory already corrupted.
+    if (length > TYPE_WIDTH) {
+      throw new IllegalArgumentException(
+          "Invalid decimal value length. Valid length in [1 - 32], got " + length);
+    }
+
     // do the bound check.
     valueBuffer.checkBytes((long) index * TYPE_WIDTH, (long) (index + 1) * TYPE_WIDTH);
 
@@ -243,8 +251,6 @@ public final class Decimal256Vector extends BaseFixedWidthVector
         return;
       }
     }
-    throw new IllegalArgumentException(
-        "Invalid decimal value length. Valid length in [1 - 32], got " + length);
   }
 
   /**
@@ -307,6 +313,11 @@ public final class Decimal256Vector extends BaseFixedWidthVector
   public void setBigEndianSafe(int index, long start, ArrowBuf buffer, int length) {
     handleSafe(index);
     BitVectorHelper.setBit(validityBuffer, index);
+
+    if (length > TYPE_WIDTH) {
+      throw new IllegalArgumentException(
+          "Invalid decimal value length. Valid length in [1 - 32], got " + length);
+    }
 
     // do the bound checks.
     buffer.checkBytes(start, start + length);

--- a/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -207,6 +207,14 @@ public final class DecimalVector extends BaseFixedWidthVector
     BitVectorHelper.setBit(validityBuffer, index);
     final int length = value.length;
 
+    // Reject an oversized value before any bytes are written. The little-endian path below
+    // copies all `length` bytes into the fixed TYPE_WIDTH slot with unchecked native writes,
+    // so validating after the copy would leave adjacent memory already corrupted.
+    if (length > TYPE_WIDTH) {
+      throw new IllegalArgumentException(
+          "Invalid decimal value length. Valid length in [1 - 16], got " + length);
+    }
+
     // do the bound check.
     valueBuffer.checkBytes((long) index * TYPE_WIDTH, (long) (index + 1) * TYPE_WIDTH);
 
@@ -241,8 +249,6 @@ public final class DecimalVector extends BaseFixedWidthVector
         return;
       }
     }
-    throw new IllegalArgumentException(
-        "Invalid decimal value length. Valid length in [1 - 16], got " + length);
   }
 
   /**
@@ -305,6 +311,11 @@ public final class DecimalVector extends BaseFixedWidthVector
   public void setBigEndianSafe(int index, long start, ArrowBuf buffer, int length) {
     handleSafe(index);
     BitVectorHelper.setBit(validityBuffer, index);
+
+    if (length > TYPE_WIDTH) {
+      throw new IllegalArgumentException(
+          "Invalid decimal value length. Valid length in [1 - 16], got " + length);
+    }
 
     // do the bound checks.
     buffer.checkBytes(start, start + length);

--- a/vector/src/test/java/org/apache/arrow/vector/TestDecimal256Vector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestDecimal256Vector.java
@@ -284,6 +284,25 @@ public class TestDecimal256Vector {
   }
 
   @Test
+  public void setBigEndianOversizedDoesNotCorruptNeighbor() {
+    try (Decimal256Vector decimalVector =
+        TestUtils.newVector(
+            Decimal256Vector.class, "decimal", new ArrowType.Decimal(60, 0, 256), allocator)) {
+      decimalVector.allocateNew(2);
+
+      // A value whose low bytes are all non-zero, stored in the slot right after the target.
+      final BigInteger neighbor = new BigInteger("305419896"); // 0x12345678
+      decimalVector.setBigEndian(1, neighbor.toByteArray());
+
+      // A value longer than the 32-byte decimal must be rejected before anything is written.
+      assertThrows(
+          IllegalArgumentException.class, () -> decimalVector.setBigEndian(0, new byte[40]));
+
+      assertEquals(neighbor, decimalVector.getObject(1).unscaledValue());
+    }
+  }
+
+  @Test
   public void setUsingArrowBufOfLEInts() {
     try (Decimal256Vector decimalVector =
             TestUtils.newVector(

--- a/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -276,6 +277,25 @@ public class TestDecimalVector {
       }
       assertTrue(decimalVector.isNull(outputIdx++));
       assertEquals(BigInteger.valueOf(0), decimalVector.getObject(outputIdx).unscaledValue());
+    }
+  }
+
+  @Test
+  public void setBigEndianOversizedDoesNotCorruptNeighbor() {
+    try (DecimalVector decimalVector =
+        TestUtils.newVector(
+            DecimalVector.class, "decimal", new ArrowType.Decimal(38, 0, 128), allocator)) {
+      decimalVector.allocateNew(2);
+
+      // A value whose low bytes are all non-zero, stored in the slot right after the target.
+      final BigInteger neighbor = new BigInteger("305419896"); // 0x12345678
+      decimalVector.setBigEndian(1, neighbor.toByteArray());
+
+      // A value longer than the 16-byte decimal must be rejected before anything is written.
+      assertThrows(
+          IllegalArgumentException.class, () -> decimalVector.setBigEndian(0, new byte[24]));
+
+      assertEquals(neighbor, decimalVector.getObject(1).unscaledValue());
     }
   }
 


### PR DESCRIPTION
## What's Changed

`setBigEndian(int, byte[])` on `DecimalVector` and `Decimal256Vector` byte-swaps the value into the fixed-width slot with unchecked `MemoryUtil` writes and only checks the length afterwards, so a byte array longer than the type width overruns the slot into adjacent off-heap memory before the `IllegalArgumentException` fires. `setBigEndianSafe(int, long, ArrowBuf, int)` does the same write with no length check at all. This moves the length check ahead of the write and adds it to the safe variant, so oversized input is rejected before any memory is touched; valid lengths are unaffected.

Closes #1246.