### PR TITLE
GH-559: [Java] Add FixedSizeBinary support to ComplexCopier

### DIFF
--- a/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/vector/src/main/codegen/templates/ComplexCopier.java
@@ -117,6 +117,17 @@ public class ComplexCopier {
           writer.writeNull();
         }
         break;
+      case FIXEDSIZEBINARY:
+        if (reader.isSet()) {
+          NullableFixedSizeBinaryHolder fixedSizeBinaryHolder = new NullableFixedSizeBinaryHolder();
+          reader.read(fixedSizeBinaryHolder);
+          if (fixedSizeBinaryHolder.isSet == 1) {
+            writer.writeFixedSizeBinary(fixedSizeBinaryHolder.buffer);
+          }
+        } else {
+          writer.writeNull();
+        }
+        break;
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
   <#assign fields = minor.fields!type.fields />
   <#assign uncappedName = name?uncap_first/>
@@ -160,6 +171,13 @@ public class ComplexCopier {
     </#if>
 
     </#list></#list>
+    case FIXEDSIZEBINARY:
+      if (reader.getField().getType() instanceof ArrowType.FixedSizeBinary) {
+        ArrowType.FixedSizeBinary type = (ArrowType.FixedSizeBinary) reader.getField().getType();
+        return (FieldWriter) writer.fixedSizeBinary(name, type.getByteWidth());
+      } else {
+        return (FieldWriter) writer.fixedSizeBinary(name);
+      }
     case STRUCT:
       return (FieldWriter) writer.struct(name);
     case FIXED_SIZE_LIST:
@@ -187,6 +205,8 @@ public class ComplexCopier {
     return (FieldWriter) writer.<#if name == "Int">integer<#else>${uncappedName}</#if>();
     </#if>
     </#list></#list>
+    case FIXEDSIZEBINARY:
+      return (FieldWriter) writer.fixedSizeBinary();
     case STRUCT:
       return (FieldWriter) writer.struct();
     case FIXED_SIZE_LIST:
@@ -214,6 +234,8 @@ public class ComplexCopier {
       return (FieldWriter) writer.<#if name == "Int">integer<#else>${uncappedName}</#if>();
     </#if>
     </#list></#list>
+      case FIXEDSIZEBINARY:
+        return (FieldWriter) writer.fixedSizeBinary();
       case STRUCT:
         return (FieldWriter) writer.struct();
       case FIXED_SIZE_LIST:

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.DecimalVector;
@@ -36,6 +38,7 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.extension.UuidType;
 import org.apache.arrow.vector.holders.DecimalHolder;
+import org.apache.arrow.vector.holders.FixedSizeBinaryHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -204,6 +207,53 @@ public class TestComplexCopier {
 
       // validate equals
       assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+    }
+  }
+
+  @Test
+  public void testCopyListOfFixedSizeBinary() {
+    final int byteWidth = 4;
+    try (ListVector from = ListVector.empty("v", allocator);
+        ListVector to = ListVector.empty("v", allocator);
+        ArrowBuf buf = allocator.buffer(byteWidth)) {
+
+      from.addOrGetVector(FieldType.nullable(new ArrowType.FixedSizeBinary(byteWidth)));
+
+      UnionListWriter listWriter = from.getWriter();
+      listWriter.allocate();
+
+      FixedSizeBinaryHolder holder = new FixedSizeBinaryHolder();
+      holder.byteWidth = byteWidth;
+      holder.buffer = buf;
+
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.setPosition(i);
+        listWriter.startList();
+
+        buf.setBytes(0, new byte[] {1, 2, 3, 4});
+        listWriter.fixedSizeBinary().write(holder);
+
+        buf.setBytes(0, new byte[] {5, 6, 7, 8});
+        listWriter.fixedSizeBinary().write(holder);
+
+        listWriter.endList();
+      }
+      from.setValueCount(COUNT);
+
+      // copy values — this currently throws UnsupportedOperationException: FIXEDSIZEBINARY
+      FieldReader in = from.getReader();
+      FieldWriter out = to.getWriter();
+      UnsupportedOperationException e =
+          assertThrows(
+              UnsupportedOperationException.class,
+              () -> {
+                for (int i = 0; i < COUNT; i++) {
+                  in.setPosition(i);
+                  out.setPosition(i);
+                  ComplexCopier.copy(in, out);
+                }
+              });
+      assertTrue(e.getMessage().contains("FIXEDSIZEBINARY"));
     }
   }
 

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -16,12 +16,14 @@
  */
 package org.apache.arrow.vector.complex.impl;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
-
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -218,6 +220,7 @@ public class TestComplexCopier {
         ArrowBuf buf = allocator.buffer(byteWidth)) {
 
       from.addOrGetVector(FieldType.nullable(new ArrowType.FixedSizeBinary(byteWidth)));
+      to.addOrGetVector(FieldType.nullable(new ArrowType.FixedSizeBinary(byteWidth)));
 
       UnionListWriter listWriter = from.getWriter();
       listWriter.allocate();
@@ -240,20 +243,26 @@ public class TestComplexCopier {
       }
       from.setValueCount(COUNT);
 
-      // copy values — this currently throws UnsupportedOperationException: FIXEDSIZEBINARY
       FieldReader in = from.getReader();
       FieldWriter out = to.getWriter();
-      UnsupportedOperationException e =
-          assertThrows(
-              UnsupportedOperationException.class,
-              () -> {
-                for (int i = 0; i < COUNT; i++) {
-                  in.setPosition(i);
-                  out.setPosition(i);
-                  ComplexCopier.copy(in, out);
-                }
-              });
-      assertTrue(e.getMessage().contains("FIXEDSIZEBINARY"));
+      for (int i = 0; i < COUNT; i++) {
+        in.setPosition(i);
+        out.setPosition(i);
+        ComplexCopier.copy(in, out);
+      }
+      to.setValueCount(COUNT);
+
+      for (int i = 0; i < COUNT; i++) {
+        @SuppressWarnings("unchecked")
+        List<byte[]> expected = (List<byte[]>) from.getObject(i);
+        @SuppressWarnings("unchecked")
+        List<byte[]> actual = (List<byte[]>) to.getObject(i);
+
+        assertEquals(expected.size(), actual.size());
+        for (int j = 0; j < expected.size(); j++) {
+          assertArrayEquals(expected.get(j), actual.get(j));
+        }
+      }
     }
   }
 

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -765,6 +765,43 @@ public class TestComplexCopier {
   }
 
   @Test
+  public void testCopyStructOfFixedSizeBinary() {
+    final int byteWidth = 4;
+    try (final StructVector from = StructVector.empty("v", allocator);
+        final StructVector to = StructVector.empty("v", allocator);
+        ArrowBuf buf = allocator.buffer(byteWidth)) {
+      from.allocateNewSafe();
+      NullableStructWriter structWriter = from.getWriter();
+
+      FixedSizeBinaryHolder holder = new FixedSizeBinaryHolder();
+      holder.byteWidth = byteWidth;
+      holder.buffer = buf;
+
+      for (int i = 0; i < COUNT; i++) {
+        structWriter.setPosition(i);
+        structWriter.start();
+        buf.setBytes(0, new byte[] {(byte) i, (byte) (i + 1), (byte) (i + 2), (byte) (i + 3)});
+        structWriter.fixedSizeBinary("fsb", byteWidth).write(holder);
+        structWriter.end();
+      }
+      from.setValueCount(COUNT);
+
+      // copy values
+      FieldReader in = from.getReader();
+      FieldWriter out = to.getWriter();
+      for (int i = 0; i < COUNT; i++) {
+        in.setPosition(i);
+        out.setPosition(i);
+        ComplexCopier.copy(in, out);
+      }
+      to.setValueCount(COUNT);
+
+      // validate equals
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+    }
+  }
+
+  @Test
   public void testCopyDecimalVectorWrongScale() {
     try (FixedSizeListVector from = FixedSizeListVector.empty("v", 3, allocator);
         FixedSizeListVector to = FixedSizeListVector.empty("v", 3, allocator)) {


### PR DESCRIPTION
### Rationale for this change
ComplexCopier did not support copying FixedSizeBinary columns nested in List, Map, Struct, or top-level contexts, throwing UnsupportedOperationException.

### What changes are included in this PR?
Adds FIXEDSIZEBINARY cases to:
- getListWriterForReader
- getStructWriterForReader
- getMapWriterForReader
- the main copy() switch

### Are these changes tested?
Yes:
- testCopyListOfFixedSizeBinary — copying a List<FixedSizeBinary>
- testCopyStructOfFixedSizeBinary — copying a Struct field of type FixedSizeBinary

Full TestComplexCopier suite (22 tests) passes with no regressions.

Note: I attempted to add equivalent coverage for Map values of type FixedSizeBinary, but ran into a pre-existing limitation unrelated to this fix — MapWriter/ListWriter's no-arg fixedSizeBinary() delegates to NullableStructWriter.fixedSizeBinary(String), which only looks up an existing child writer and never creates one. The byteWidth-aware overload that does create the vector isn't reachable through the public MapWriter/ListWriter interface. This appears to be a gap in the writer codegen itself rather than something ComplexCopier can work around, so I've left it untested here — happy to open a follow-up issue if that's useful, or take a stab at it if maintainers think it's in scope for this PR.

Closes #559