### PR TITLE
GH-1257: cover arrow-memory-netty-buffer-patch in BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -181,6 +181,11 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-netty-buffer-patch</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-memory-unsafe</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
## What's Changed

This package was missing in the BOM leaving it open to becoming out of sync with the rest of the packages.

Closes #1257.