### PR TITLE
MINOR: actually throw in PooledByteBufAllocatorL

### DIFF
--- a/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -82,7 +82,7 @@ public class PooledByteBufAllocatorL {
   }
 
   public long getNormalBufferCount() {
-    return normalBufferSize.get();
+    return normalBufferCount.get();
   }
 
   private static class AccountedUnsafeDirectLittleEndian extends UnsafeDirectLittleEndian {

--- a/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -172,7 +172,7 @@ public class PooledByteBufAllocatorL {
           // within chunk, use arena.
           ByteBuf buf = directArena.allocate(cache, initialCapacity, maxCapacity);
           if (!(buf instanceof PooledUnsafeDirectByteBuf)) {
-            fail();
+            throw fail();
           }
 
           if (!AssertionUtil.ASSERT_ENABLED) {


### PR DESCRIPTION
## What's Changed

There was a check in that class that looks like it throws an exception, but actually does not. This means that when that branch is hit, instead of an actionable error, the user gets a ClassCastException like

```
java.lang.ClassCastException: class io.netty.buffer.PooledDirectByteBuf cannot be cast to class io.netty.buffer.PooledUnsafeDirectByteBuf (io.netty.buffer.PooledDirectByteBuf and io.netty.buffer.PooledUnsafeDirectByteBuf are in unnamed module of loader org.springframework.boot.loader.launch.LaunchedClassLoader@5e9f23b4)
```

Actually throwing the exception prevents this and should not break anything: there is still an exception being thrown, just a different type.

Also, make getNormalBufferCount actually return the count, not the size.
