### PR TITLE
GH-1241: Bump vcpkg version to stay in sync with apache/arrow

### DIFF
--- a/.env
+++ b/.env
@@ -53,4 +53,4 @@ MAVEN=3.9.9
 # Versions for various dependencies used to build artifacts
 # Keep in sync with apache/arrow
 ARROW_REPO_ROOT=./arrow
-VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release
+VCPKG="9b965a116838c6cdcd36bca60d1b81b030c8ab8d"    # 2026.05.27 (not release, upstream commit)


### PR DESCRIPTION
This fixes the CI for Linux.

Closes #1241.