### PR TITLE
MINOR: Update google-java-format and test Java 25 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [17, 21, 23]
-        maven: [3.9.9]
+        jdk: [17, 21, 25]
+        maven: [3.9.16]
         image: [ubuntu, conda-jni-cdata]
         include:
           - image: ubuntu

--- a/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
+++ b/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/ArrowToAvroUtils.java
@@ -601,7 +601,7 @@ public class ArrowToAvroUtils {
       case VARCHAR:
         return new AvroStringProducer((VarCharVector) vector);
 
-        // Logical types
+      // Logical types
 
       case DECIMAL:
         return new AvroDecimalProducer((DecimalVector) vector);
@@ -636,7 +636,7 @@ public class ArrowToAvroUtils {
       case TIMESTAMPNANOTZ:
         return new AvroTimestampNanoTzProducer((TimeStampNanoTZVector) vector);
 
-        // Complex types
+      // Complex types
 
       case STRUCT:
         StructVector structVector = (StructVector) vector;
@@ -679,9 +679,9 @@ public class ArrowToAvroUtils {
             new AvroStructProducer(entryVector, new Producer<?>[] {keyProducer, valueProducer});
         return new AvroMapProducer(mapVector, entryProducer);
 
-        // Support for UNION and DENSEUNION is not currently available
-        // This is pending fixes in the implementation of the union vectors themselves
-        // https://github.com/apache/arrow-java/issues/108
+      // Support for UNION and DENSEUNION is not currently available
+      // This is pending fixes in the implementation of the union vectors themselves
+      // https://github.com/apache/arrow-java/issues/108
 
       default:
         // Not all Arrow types are supported for encoding (yet)!

--- a/adapter/jdbc/pom.xml
+++ b/adapter/jdbc/pom.xml
@@ -32,6 +32,10 @@ under the License.
   <description>(Contrib/Experimental)A library for converting JDBC data to Arrow data.</description>
   <url>http://maven.apache.org</url>
 
+  <properties>
+    <surefire.argLine.extend>--add-reads=org.apache.arrow.adapter.jdbc=com.fasterxml.jackson.dataformat.yaml</surefire.argLine.extend>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -108,13 +112,6 @@ under the License.
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration combine.self="override">
-          <argLine>--add-reads=org.apache.arrow.adapter.jdbc=com.fasterxml.jackson.dataformat.yaml --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -Duser.timezone=UTC</argLine>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/dataset/pom.xml
+++ b/dataset/pom.xml
@@ -31,6 +31,7 @@ under the License.
   <description>Java implementation of Arrow Dataset API/Framework</description>
 
   <properties>
+    <surefire.argLine.extend>--add-reads=org.apache.arrow.dataset=com.fasterxml.jackson.databind --add-opens=java.base/java.nio=org.apache.arrow.dataset</surefire.argLine.extend>
     <arrow.cpp.build.dir>../../../cpp/release-build/</arrow.cpp.build.dir>
     <parquet.version>1.17.1</parquet.version>
     <avro.version>1.12.1</avro.version>
@@ -180,7 +181,6 @@ under the License.
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine combine.self="override">--add-reads=org.apache.arrow.dataset=com.fasterxml.jackson.databind --add-opens=java.base/java.nio=org.apache.arrow.dataset,org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
           <enableAssertions>false</enableAssertions>
           <systemPropertyVariables>
             <arrow.test.dataRoot>${project.basedir}/../testing/data</arrow.test.dataRoot>

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -28,10 +28,13 @@ Java Compatibility
 ==================
 
 Java modules are compatible with JDK 17 and above. Currently, JDK versions
-17, 21, and latest are tested in CI.
+17, 21, and 25 are tested in CI.
 
-Note that some JDK internals must be exposed by
-adding ``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`` to the ``java`` command:
+Note that some JDK internals must be exposed by adding these flags to the ``java`` command:
+
+- ``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`` (always required)
+- ``--enable-native-access=io.netty.common`` (Java 25+, when using ``arrow-memory-netty``)
+- ``--sun-misc-unsafe-memory-access=allow`` (Java 25+; not stricly necessary, but suppresses certain warnings)
 
 .. code-block:: shell
 
@@ -40,9 +43,11 @@ adding ``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
    # Indirectly via environment variables
    $ env JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
 
-Otherwise, you may see errors like ``module java.base does not "opens
-java.nio" to unnamed module`` or ``module java.base does not "opens
-java.nio" to org.apache.arrow.memory.core``
+Otherwise, you may see errors and/or warnings like these:
+- ``module java.base does not "opens java.nio" to unnamed module``
+- ``module java.base does not "opens java.nio" to org.apache.arrow.memory.core``
+- ``Native access (restricted methods) is not enabled for the io.netty.common module.``
+- ``A terminally deprecated method in sun.misc.Unsafe has been called``
 
 Note that the command has changed from Arrow 15 and earlier. If you are still using the flags from that version
 (``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED``) you will see the

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -53,6 +53,9 @@ Note that the command has changed from Arrow 15 and earlier. If you are still us
 (``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED``) you will see the
 ``module java.base does not "opens java.nio" to org.apache.arrow.memory.core`` error.
 
+For more information on these flags, see the `Netty documentation
+<https://netty.io/wiki/java-24-and-sun.misc.unsafe.html>`_.
+
 If you are using flight-core or dependent modules, you will need to mark that flight-core can read unnamed modules.
 Modifying the command above for Flight:
 

--- a/flight/flight-core/pom.xml
+++ b/flight/flight-core/pom.xml
@@ -32,8 +32,7 @@ under the License.
 
   <properties>
     <forkCount>1</forkCount>
-    <!-- List of add-opens arg line arguments for this module's tests -->
-    <surefire.add-opens.argLine>--add-opens=org.apache.arrow.flight.core/org.apache.arrow.flight.perf.impl=protobuf.java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</surefire.add-opens.argLine>
+    <surefire.argLine.extend>--add-opens=org.apache.arrow.flight.core/org.apache.arrow.flight.perf.impl=protobuf.java</surefire.argLine.extend>
   </properties>
 
   <dependencies>
@@ -152,7 +151,6 @@ under the License.
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine combine.self="override">--add-opens=org.apache.arrow.flight.core/org.apache.arrow.flight.perf.impl=protobuf.java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
           <enableAssertions>false</enableAssertions>
           <systemPropertyVariables>
             <arrow.test.dataRoot>${project.basedir}/../../testing/data</arrow.test.dataRoot>

--- a/flight/flight-sql/pom.xml
+++ b/flight/flight-sql/pom.xml
@@ -32,8 +32,7 @@ under the License.
 
   <properties>
     <forkCount>1</forkCount>
-    <!-- List of add-opens arg line arguments for this module's tests -->
-    <surefire.add-opens.argLine>--add-reads=org.apache.arrow.flight.sql=org.slf4j --add-reads=org.apache.arrow.flight.core=ALL-UNNAMED --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</surefire.add-opens.argLine>
+    <surefire.argLine.extend>--add-reads=org.apache.arrow.flight.sql=org.slf4j --add-reads=org.apache.arrow.flight.core=ALL-UNNAMED</surefire.argLine.extend>
   </properties>
 
   <dependencies>

--- a/memory/memory-core/pom.xml
+++ b/memory/memory-core/pom.xml
@@ -31,8 +31,7 @@ under the License.
   <description>Core off-heap memory management libraries for Arrow ValueVectors.</description>
 
   <properties>
-    <!-- List of add-opens arg line arguments for this module's tests -->
-    <surefire.add-opens.argLine>--add-reads=org.apache.arrow.memory.core=ch.qos.logback.classic --add-opens=java.base/java.lang.reflect=org.apache.arrow.memory.core --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</surefire.add-opens.argLine>
+    <surefire.argLine.extend>--add-reads=org.apache.arrow.memory.core=ch.qos.logback.classic --add-opens=java.base/java.lang.reflect=org.apache.arrow.memory.core</surefire.argLine.extend>
   </properties>
 
   <dependencies>
@@ -84,7 +83,6 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>--add-reads=org.apache.arrow.memory.core=ch.qos.logback.classic --add-opens=java.base/java.lang.reflect=org.apache.arrow.memory.core --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
           <excludes>
             <!-- Test is only useful when NOT running with add-opens -->
             <exclude>**/TestOpens.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ under the License.
     <doclint>none</doclint>
     <additionalparam>-Xdoclint:none</additionalparam>
     <!-- List of add-opens arg line arguments for tests -->
-    <surefire.add-opens.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</surefire.add-opens.argLine>
+    <surefire.add-opens.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED --enable-native-access=io.netty.common --sun-misc-unsafe-memory-access=allow</surefire.add-opens.argLine>
     <!-- org.apache:apache overrides -->
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
     <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@ under the License.
     <logback.version>1.6.3</logback.version>
     <doclint>none</doclint>
     <additionalparam>-Xdoclint:none</additionalparam>
-    <!-- List of add-opens arg line arguments for tests -->
-    <surefire.add-opens.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED --enable-native-access=io.netty.common ${surefire.unsafe-memory-access.argLine}</surefire.add-opens.argLine>
-    <surefire.unsafe-memory-access.argLine/>
+    <surefire.argLine.extend/>
+    <surefire.argLine.jdkSpecific/>
+    <surefire.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED --enable-native-access=io.netty.common ${surefire.argLine.extend} ${surefire.argLine.jdkSpecific}</surefire.argLine>
     <!-- org.apache:apache overrides -->
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
     <maven.compiler.source>17</maven.compiler.source>
@@ -323,7 +323,7 @@ under the License.
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <argLine>${surefire.add-opens.argLine}</argLine>
+            <argLine>${surefire.argLine}</argLine>
             <enableAssertions>true</enableAssertions>
             <childDelegation>true</childDelegation>
             <forkCount>${forkCount}</forkCount>
@@ -342,7 +342,7 @@ under the License.
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
-            <argLine>${surefire.add-opens.argLine}</argLine>
+            <argLine>${surefire.argLine}</argLine>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
@@ -786,7 +786,7 @@ under the License.
         <jdk>[24,)</jdk>
       </activation>
       <properties>
-        <surefire.unsafe-memory-access.argLine>--sun-misc-unsafe-memory-access=allow</surefire.unsafe-memory-access.argLine>
+        <surefire.argLine.jdkSpecific>--sun-misc-unsafe-memory-access=allow</surefire.argLine.jdkSpecific>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -725,42 +725,6 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <configuration>
-          <pom>
-            <licenseHeader>
-              <file>${maven.multiModuleProjectDirectory}/dev/license/asf-xml.license</file>
-              <delimiter>(&lt;configuration|&lt;project)</delimiter>
-            </licenseHeader>
-            <sortPom/>
-          </pom>
-          <java>
-            <googleJavaFormat>
-              <version>1.36.1</version>
-              <style>GOOGLE</style>
-            </googleJavaFormat>
-            <licenseHeader>
-              <file>${maven.multiModuleProjectDirectory}/dev/license/asf-java.license</file>
-              <delimiter>package</delimiter>
-            </licenseHeader>
-            <excludes>
-              <exclude>**/Preconditions.java</exclude>
-              <exclude>**/IntObjectMap.java</exclude>
-              <exclude>**/IntObjectHashMap.java</exclude>
-            </excludes>
-          </java>
-        </configuration>
-        <executions>
-          <execution>
-            <id>spotless-check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
     <extensions>
       <!-- provides os.detected.classifier (i.e. linux-x86_64, osx-x86_64) property -->
@@ -840,6 +804,54 @@ under the License.
       <properties>
         <arrow.vector.classifier>shade-format-flatbuffers</arrow.vector.classifier>
       </properties>
+    </profile>
+
+    <profile>
+      <!-- google-java-format now requires Java 21+ -->
+      <id>spotless</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <configuration>
+              <pom>
+                <licenseHeader>
+                  <file>${maven.multiModuleProjectDirectory}/dev/license/asf-xml.license</file>
+                  <delimiter>(&lt;configuration|&lt;project)</delimiter>
+                </licenseHeader>
+                <sortPom/>
+              </pom>
+              <java>
+                <googleJavaFormat>
+                  <version>1.36.1</version>
+                  <style>GOOGLE</style>
+                </googleJavaFormat>
+                <licenseHeader>
+                  <file>${maven.multiModuleProjectDirectory}/dev/license/asf-java.license</file>
+                  <delimiter>package</delimiter>
+                </licenseHeader>
+                <excludes>
+                  <exclude>**/Preconditions.java</exclude>
+                  <exclude>**/IntObjectMap.java</exclude>
+                  <exclude>**/IntObjectHashMap.java</exclude>
+                </excludes>
+              </java>
+            </configuration>
+            <executions>
+              <execution>
+                <id>spotless-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,8 @@ under the License.
     <doclint>none</doclint>
     <additionalparam>-Xdoclint:none</additionalparam>
     <!-- List of add-opens arg line arguments for tests -->
-    <surefire.add-opens.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED --enable-native-access=io.netty.common --sun-misc-unsafe-memory-access=allow</surefire.add-opens.argLine>
+    <surefire.add-opens.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED --enable-native-access=io.netty.common ${surefire.unsafe-memory-access.argLine}</surefire.add-opens.argLine>
+    <surefire.unsafe-memory-access.argLine/>
     <!-- org.apache:apache overrides -->
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
     <maven.compiler.source>17</maven.compiler.source>
@@ -778,6 +779,17 @@ under the License.
   </reporting>
 
   <profiles>
+    <profile>
+      <!-- Certain flags are required on newer JDK but not recognized on earlier JDK -->
+      <id>jdk24</id>
+      <activation>
+        <jdk>[24,)</jdk>
+      </activation>
+      <properties>
+        <surefire.unsafe-memory-access.argLine>--sun-misc-unsafe-memory-access=allow</surefire.unsafe-memory-access.argLine>
+      </properties>
+    </profile>
+
     <profile>
       <!-- C data interface depends on building a native library -->
       <id>arrow-c-data</id>

--- a/pom.xml
+++ b/pom.xml
@@ -738,7 +738,7 @@ under the License.
           </pom>
           <java>
             <googleJavaFormat>
-              <version>1.17.0</version>
+              <version>1.36.1</version>
               <style>GOOGLE</style>
             </googleJavaFormat>
             <licenseHeader>

--- a/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -53,10 +53,8 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * <p>This interface "should" strive to guarantee this order of operation:
  *
  * <blockquote>
- *
  * allocate &gt; mutate &gt; setvaluecount &gt; access &gt; clear (or allocate to start the process
  * over).
- *
  * </blockquote>
  */
 public interface ValueVector extends Closeable, Iterable<ValueVector> {

--- a/vector/src/main/java/org/apache/arrow/vector/util/Text.java
+++ b/vector/src/main/java/org/apache/arrow/vector/util/Text.java
@@ -488,7 +488,7 @@ public class Text extends ReusableByteArray {
           if (leadByte == 0xED && aByte > 0x9F) {
             return Optional.of(count);
           }
-          // falls through to regular trail-byte test!!
+        // falls through to regular trail-byte test!!
         case TRAIL_BYTE:
           if (aByte < 0x80 || aByte > 0xBF) {
             return Optional.of(count);
@@ -793,23 +793,23 @@ public class Text extends ReusableByteArray {
       case 5:
         ch += (bytes.get() & 0xFF);
         ch <<= 6; /* remember, illegal UTF-8 */
-        // fall through
+      // fall through
       case 4:
         ch += (bytes.get() & 0xFF);
         ch <<= 6; /* remember, illegal UTF-8 */
-        // fall through
+      // fall through
       case 3:
         ch += (bytes.get() & 0xFF);
         ch <<= 6;
-        // fall through
+      // fall through
       case 2:
         ch += (bytes.get() & 0xFF);
         ch <<= 6;
-        // fall through
+      // fall through
       case 1:
         ch += (bytes.get() & 0xFF);
         ch <<= 6;
-        // fall through
+      // fall through
       case 0:
         ch += (bytes.get() & 0xFF);
         break;


### PR DESCRIPTION
## What's Changed

- Test Java 25 (LTS) instead of Java 23
- Update google-java-format since it broke on Java 25
- Reformat code
- Deduplicate/make argLine config consistent
- Update flags and docs for Java 25