### PR TITLE
MINOR: Don't install Homebrew's aws-sdk-cpp and gRPC for JNI macOS build

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -236,13 +236,29 @@ jobs:
             brew uninstall pkg-config@0.29.2 || :
           fi
 
-          brew bundle --file=arrow/cpp/Brewfile
+          # We don't use Homebrew's aws-sdk-cpp and gRPC. See the
+          # "brew uninstall" calls below for details. So we don't install
+          # them instead of installing and uninstalling them.
+          #
+          # This is also needed because Homebrew doesn't provide bottles
+          # for them on x86_64 macOS. Homebrew treats x86_64 macOS as a
+          # tier 3 configuration and rarely builds bottles for it:
+          #
+          #   https://docs.brew.sh/Support-Tiers#tier-3
+          #
+          # "brew bundle" fails with "no bottle available!" without this
+          # because it doesn't build them from source.
+          HOMEBREW_BUNDLE_BREW_SKIP="aws-sdk-cpp grpc" \
+            brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have
           # Homebrew's aws-sdk-cpp, our build mix Homebrew's
           # aws-sdk-cpp and bundled aws-sdk-cpp. We uninstall Homebrew's
           # aws-sdk-cpp to ensure using only bundled aws-sdk-cpp.
-          brew uninstall aws-sdk-cpp
+          #
+          # Homebrew's aws-sdk-cpp may be pre-installed on GitHub Actions
+          # runner images even if we skip installing it above.
+          brew uninstall aws-sdk-cpp || :
           # We want to use bundled RE2 for static linking. If
           # Homebrew's RE2 is installed, its header file may be used.
           # We uninstall Homebrew's RE2 to ensure using bundled RE2.


### PR DESCRIPTION
### Rationale for this change

The `JNI macos-15-intel x86_64` job in the RC workflow fails in `Install dependencies`, before anything is built:

```
##[error]aws-sdk-cpp: no bottle available!
##[error]grpc: no bottle available!
This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
`brew bundle` failed! 2 Brewfile dependencies failed to install
```

Homebrew treats x86_64 macOS as a [tier 3 configuration](https://docs.brew.sh/Support-Tiers#tier-3) and rarely publishes bottles for it. `brew bundle` doesn't build from source, so `arrow/cpp/Brewfile` can no longer be installed as-is there.

This breaks `main` too, not just PRs, so nightly RC runs are red.

### What changes are included in this PR?

We don't use Homebrew's `aws-sdk-cpp` and gRPC anyway:

* The JNI macOS build uses the `ninja-release-jni-macos` preset, which sets `ARROW_DEPENDENCY_USE_SHARED=OFF`.
* Homebrew provides only shared libraries for `aws-sdk-cpp` and gRPC.
* So both are uninstalled just after `brew bundle` to ensure the bundled ones are used.

We skip installing them with `HOMEBREW_BUNDLE_BREW_SKIP` instead of installing and uninstalling them. This also makes the `macos-14` `aarch_64` job a bit faster because it no longer installs two formulae it immediately removes.

`brew uninstall aws-sdk-cpp` needs `|| :` now because it's no longer installed by `brew bundle`. It's still called because it may be pre-installed on GitHub Actions runner images.

Note that this keeps building the x86_64 macOS shared libraries. Dropping the `macos-15-intel` entry would remove `.dylib` files for x86_64 macOS from our release JARs, which needs a separate discussion.

### Are these changes tested?

Yes, by CI. The `JNI macos-15-intel x86_64` and `JNI macos-14 aarch_64` jobs in this PR exercise the changed step.

### Are there any user-facing changes?

No.