### PR TITLE
MINOR: Don't install Homebrew's Node.js for JNI macOS build

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -248,7 +248,10 @@ jobs:
           #
           # "brew bundle" fails with "no bottle available!" without this
           # because it doesn't build them from source.
-          HOMEBREW_BUNDLE_BREW_SKIP="aws-sdk-cpp grpc" \
+          #
+          # We don't use Homebrew's Node.js too. Homebrew doesn't provide
+          # a bottle for it on x86_64 macOS for the same reason.
+          HOMEBREW_BUNDLE_BREW_SKIP="aws-sdk-cpp grpc node" \
             brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have


### PR DESCRIPTION
The `JNI macos-15-intel x86_64` job currently fails on `main` and on every open PR while installing dependencies:

```
==> Installing node
Error: node: no bottle available!
This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
Installing node has failed!
`brew bundle` failed! 1 Brewfile dependency failed to install
```

`apache/arrow`'s `cpp/Brewfile` lists `brew "node"`, and Homebrew treats x86_64 macOS as a tier 3 configuration and no longer builds a bottle for it. `brew bundle` doesn't build from source, so the step aborts before anything is built.

We don't need Node.js for the JNI build, so this skips installing it via `HOMEBREW_BUNDLE_BREW_SKIP`, the same way #1269 did for `aws-sdk-cpp` and gRPC.

Failing runs for reference:

* `main`: https://github.com/apache/arrow-java/actions/runs/33283736388/job/99183221397
* PR #1263: https://github.com/apache/arrow-java/actions/runs/33297775855/job/99221106761