### PR TITLE
MINOR: Bump org.apache.hive:hive-storage-api from 4.0.1 to 4.1.0

### DIFF
--- a/adapter/orc/pom.xml
+++ b/adapter/orc/pom.xml
@@ -130,7 +130,7 @@ under the License.
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
-      <version>4.0.1</version>
+      <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dataset/pom.xml
+++ b/dataset/pom.xml
@@ -151,7 +151,7 @@ under the License.
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
-      <version>4.0.1</version>
+      <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Supersedes #1280.

Dependabot proposed bumping `org.apache.hive:hive-storage-api` to 4.2.1 in #1280, but that fails the RC `Binaries` job:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.15.0:testCompile (default-testCompile) on project arrow-orc: Compilation failure
[ERROR] adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java:[34,44] cannot access BytesColumnVector
[ERROR]   bad class file: hive-storage-api-4.2.1.jar(/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.class)
[ERROR]     class file has wrong version 65.0, should be 61.0
```

Hive moved its compiler target from Java 17 to Java 21 in 4.2.0, so 4.2.x class files (major version 65) cannot be read by `javac --release 17`, which is what this project builds with (`maven.compiler.release=17`).

| hive-storage-api | `maven.compiler.target` |
| --- | --- |
| 4.0.1 (current) | 17 |
| 4.1.0 (this PR) | 17 |
| 4.2.0 | 21 |
| 4.2.1 | 21 |

4.1.0 is the newest release still targeting Java 17, so bump to that instead. Once the project raises its baseline to Java 21, 4.2.x becomes viable.

Note that this only surfaces in the RC `Binaries` job: `ci/scripts/test.sh` adds `adapter/orc` and `dataset` to the reactor only when `ARROW_JAVA_JNI=ON`, and the Conda JNI jobs run with `-DARROW_JAVA_JNI_ENABLE_ORC=OFF`.

### Verification

`mvn -Parrow-jni -pl adapter/orc -am test-compile` and the same for `dataset` both succeed locally, including `OrcReaderTest`, the class that fails on #1280.