### PR TITLE
GH-1271: [Flight] Reject port 0 in NettyClientBuilder

### DIFF
--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -822,7 +822,13 @@ public class FlightClient implements AutoCloseable {
       return this;
     }
 
-    /** Create the client from this builder. */
+    /**
+     * Create the client from this builder.
+     *
+     * @throws IllegalArgumentException if the location uses a TCP-based scheme ({@code grpc},
+     *     {@code grpc+tcp}, {@code grpc+tls}) and the location contains no port, or a port outside
+     *     the range [1, 65535].
+     */
     public FlightClient build() {
       final NettyChannelBuilder channelBuilder = builder.build();
       return new FlightClient(builder.allocator(), channelBuilder.build(), builder.middleware());

--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
@@ -140,9 +140,9 @@ public class NettyClientBuilder {
       case LocationSchemes.GRPC_TLS:
         {
           final int port = location.getUri().getPort();
-          if (port < 0 || port > 65535) {
+          if (port < 1 || port > 65535) {
             throw new IllegalArgumentException(
-                "Invalid port " + port + ": must be between 0 and 65535.");
+                "Invalid port " + port + ": must be between 1 and 65535.");
           }
           builder = NettyChannelBuilder.forAddress(location.getUri().getHost(), port);
           break;

--- a/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
+++ b/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/NettyClientBuilder.java
@@ -130,7 +130,13 @@ public class NettyClientBuilder {
     return this;
   }
 
-  /** Create the client from this builder. */
+  /**
+   * Create the client from this builder.
+   *
+   * @throws IllegalArgumentException if the URI uses a TCP-based scheme ({@code grpc}, {@code
+   *     grpc+tcp}, {@code grpc+tls}) and the URI contains no port, or a port outside the range [1,
+   *     65535].
+   */
   public NettyChannelBuilder build() {
     final NettyChannelBuilder builder;
 
@@ -140,6 +146,10 @@ public class NettyClientBuilder {
       case LocationSchemes.GRPC_TLS:
         {
           final int port = location.getUri().getPort();
+          if (port == -1) {
+            throw new IllegalArgumentException(
+                "No port specified in location URI: " + location.getUri());
+          }
           if (port < 1 || port > 65535) {
             throw new IllegalArgumentException(
                 "Invalid port " + port + ": must be between 1 and 65535.");

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionMutualTlsTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionMutualTlsTest.java
@@ -184,6 +184,7 @@ public class ConnectionMutualTlsTest {
     try (ArrowFlightSqlClientHandler client =
         new ArrowFlightSqlClientHandler.Builder()
             .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
+            .withPort(FLIGHT_SERVER_TEST_EXTENSION.getPort())
             .withTlsRootCertificates(tlsRootCertsPath)
             .withClientCertificate(clientMTlsCertPath)
             .withClientKey(clientMTlsKeyPath)

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -63,6 +63,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link Connection}. */
 public class ConnectionTest {
@@ -204,13 +206,12 @@ public class ConnectionTest {
   }
 
   /**
-   * Checks if the exception IllegalArgumentException is thrown when trying to establish an
-   * unencrypted connection providing with an invalid port.
-   *
-   * @throws SQLException on error.
+   * Checks if a SQLException is thrown when trying to establish an unencrypted connection with an
+   * invalid port (out-of-range or reserved port 0).
    */
-  @Test
-  public void testUnencryptedConnectionProvidingInvalidPort() throws Exception {
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, 65536, 65537})
+  public void testUnencryptedConnectionProvidingInvalidPort(int invalidPort) {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
@@ -218,7 +219,7 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
     final String invalidUrl =
-        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_EXTENSION.getHost() + ":" + 65537;
+        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_EXTENSION.getHost() + ":" + invalidPort;
 
     assertThrows(
         SQLException.class,

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -240,6 +240,7 @@ public class ConnectionTest {
     try (ArrowFlightSqlClientHandler client =
         new ArrowFlightSqlClientHandler.Builder()
             .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
+            .withPort(FLIGHT_SERVER_TEST_EXTENSION.getPort())
             .withBufferAllocator(allocator)
             .withEncryption(false)
             .build()) {

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -207,7 +207,7 @@ public class ConnectionTest {
 
   /**
    * Checks if a SQLException is thrown when trying to establish an unencrypted connection with an
-   * invalid port (out-of-range or reserved port 0).
+   * invalid port.
    */
   @ParameterizedTest
   @ValueSource(ints = {0, -1, 65536, 65537})

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsRootCertsTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsRootCertsTest.java
@@ -135,6 +135,7 @@ public class ConnectionTlsRootCertsTest {
     try (ArrowFlightSqlClientHandler client =
         new ArrowFlightSqlClientHandler.Builder()
             .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
+            .withPort(FLIGHT_SERVER_TEST_EXTENSION.getPort())
             .withTlsRootCertificates(tlsRootCertsPath)
             .withBufferAllocator(allocator)
             .withEncryption(true)

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
@@ -172,6 +172,7 @@ public class ConnectionTlsTest {
     try (ArrowFlightSqlClientHandler client =
         new ArrowFlightSqlClientHandler.Builder()
             .withHost(FLIGHT_SERVER_TEST_EXTENSION.getHost())
+            .withPort(FLIGHT_SERVER_TEST_EXTENSION.getPort())
             .withSystemTrustStore(false)
             .withTrustStorePath(trustStorePath)
             .withTrustStorePassword(trustStorePass)


### PR DESCRIPTION
## What's changed

Port validation in `NettyClientBuilder.build()` is tightened to explicitly disallow port 0, as it is not a valid destination port number for a client.
Tests that made use of port 0 were updated to use a valid port under the new validation.

## Are these changes tested?
Yes. `ConnectionTest.testUnencryptedConnectionProvidingInvalidPort` was expanded to cover more invalid ports, including port 0.

This change was created with AI assistance (Claude Code). All lines were manually reviewed by a human. The output is not copyrightable subject matter.

Closes #1271. 
