### PR TITLE
GH-812: Fix appending to an empty UnionVector

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
+++ b/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
@@ -601,8 +601,8 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
     UnionVector targetUnionVector = (UnionVector) targetVector;
     int newValueCount = targetVector.getValueCount() + deltaVector.getValueCount();
 
-    // make sure there is enough capacity
-    while (targetUnionVector.getValueCapacity() < newValueCount) {
+    // Child vectors are created and expanded below; an empty union has zero value capacity.
+    while (targetUnionVector.getTypeBuffer().capacity() / UnionVector.TYPE_WIDTH < newValueCount) {
       targetUnionVector.reAlloc();
     }
 

--- a/vector/src/test/java/org/apache/arrow/vector/util/TestVectorAppender.java
+++ b/vector/src/test/java/org/apache/arrow/vector/util/TestVectorAppender.java
@@ -805,6 +805,26 @@ public class TestVectorAppender {
   }
 
   @Test
+  public void testAppendToEmptyUnionVector() {
+    try (BufferAllocator limitedAllocator = allocator.newChildAllocator("empty union", 0, 1048576);
+        UnionVector target = UnionVector.empty("target", limitedAllocator);
+        UnionVector delta = UnionVector.empty("delta", limitedAllocator)) {
+      delta.setType(0, Types.MinorType.FLOAT4);
+      delta.setType(1, Types.MinorType.FLOAT4);
+      Float4Vector values = delta.getFloat4Vector();
+      values.allocateNew();
+      ValueVectorDataPopulator.setVector(values, 1f, 2f);
+      delta.setValueCount(2);
+
+      delta.accept(new VectorAppender(target), null);
+
+      assertEquals(2, target.getValueCount());
+      assertEquals(1f, target.getObject(0));
+      assertEquals(2f, target.getObject(1));
+    }
+  }
+
+  @Test
   public void testAppendUnionVector() {
     final int length1 = 10;
     final int length2 = 5;


### PR DESCRIPTION
## What's Changed

Appending to a newly created `UnionVector` repeatedly reallocates its type buffer until allocation fails: its value capacity remains zero until it has child vectors. Check the type buffer capacity at this stage, since the existing append loop creates and expands the child vectors afterward.

The regression appends two floats to an empty union with a bounded allocator. It fails before the change with an allocation error and passes afterward. All 32 `TestVectorAppender` tests pass with both the Netty and Unsafe allocators on JDK 21. Checkstyle and Spotless also pass.

Closes #812.

Validation (JDK 21):

```sh
mvn -B -pl vector -am test -Dtest=TestVectorAppender -Dsurefire.failIfNoSpecifiedTests=false
mvn -B -pl vector spotless:check
```

Developed with AI assistance; the regression was verified to fail before the fix and pass afterward.
